### PR TITLE
use of transaction for token holder creation

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"database/sql"
+
 	"github.com/vocdoni/census3/census"
 	queries "github.com/vocdoni/census3/db/sqlc"
 	"go.vocdoni.io/dvote/httprouter"
@@ -18,16 +20,18 @@ type Census3APIConf struct {
 type census3API struct {
 	conf     Census3APIConf
 	web3     string
+	db       *sql.DB
 	sqlc     *queries.Queries
 	endpoint *api.API
 	censusDB *census.CensusDB
 }
 
-func Init(db *queries.Queries, conf Census3APIConf) error {
+func Init(db *sql.DB, q *queries.Queries, conf Census3APIConf) error {
 	newAPI := &census3API{
 		conf: conf,
 		web3: conf.Web3URI,
-		sqlc: db,
+		db:   db,
+		sqlc: q,
 	}
 	// create a new http router with the hostname and port provided in the conf
 	r := httprouter.HTTProuter{}

--- a/cmd/census3/main.go
+++ b/cmd/census3/main.go
@@ -27,19 +27,19 @@ func main() {
 	flag.Parse()
 	log.Init(*logLevel, "stdout")
 
-	db, err := db.Init(*dataDir)
+	db, q, err := db.Init(*dataDir)
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	// Start the holder scanner
-	hc, err := service.NewHoldersScanner(db, *url)
+	hc, err := service.NewHoldersScanner(db, q, *url)
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	// Start the API
-	err = api.Init(db, api.Census3APIConf{
+	err = api.Init(db, q, api.Census3APIConf{
 		Hostname: "0.0.0.0",
 		Port:     *port,
 		DataDir:  *dataDir,


### PR DESCRIPTION
Implement transactions to create token holders. This change aims to solve problems with large groups of holders in a few blocks. 