### PR TITLE
Feature/birthblock

### DIFF
--- a/api/tokens.go
+++ b/api/tokens.go
@@ -108,13 +108,18 @@ func (capi *census3API) createToken(msg *api.APIdata, ctx *httprouter.HTTPContex
 		log.Errorw(ErrCantGetToken, err.Error())
 		return ErrCantGetToken
 	}
+	birthBlock, err := w3.GetContractCreationBlock(internalCtx)
+	if err != nil {
+		log.Errorw(ErrCantGetToken, err.Error())
+		return ErrCantGetToken
+	}
 	_, err = capi.sqlc.CreateToken(internalCtx, queries.CreateTokenParams{
 		ID:            info.Address.Bytes(),
 		Name:          *name,
 		Symbol:        *symbol,
 		Decimals:      *decimals,
 		TotalSupply:   info.TotalSupply.Bytes(),
-		CreationBlock: int64(req.StartBlock),
+		CreationBlock: int64(birthBlock),
 		TypeID:        int64(tokenType),
 	})
 	if err != nil {

--- a/api/types.go
+++ b/api/types.go
@@ -3,9 +3,8 @@ package api
 import "math/big"
 
 type CreateTokenRequest struct {
-	ID         string `json:"id"`
-	Type       string `type:"type"`
-	StartBlock uint64 `type:"startBlock"`
+	ID   string `json:"id"`
+	Type string `type:"type"`
 }
 
 type GetTokenStatusResponse struct {

--- a/db/db.go
+++ b/db/db.go
@@ -22,21 +22,11 @@ func Init(dataDir string) (*queries.Queries, error) {
 			return nil, fmt.Errorf("error creating a new database file: %w", err)
 		}
 	}
-
-	// if _, err := os.Stat(dbFile); err != nil {
-	// 	fd, err := os.Create(dbFile)
-	// 	if err != nil {
-	// 		return nil, fmt.Errorf("error creating a new database file: %w", err)
-	// 	}
-	// 	fd.Close()
-	// }
-
 	// open database file
 	database, err := sql.Open("sqlite3", dbFile)
 	if err != nil {
 		return nil, fmt.Errorf("error opening database: %w", err)
 	}
-	fmt.Println(filepath.Join(dataDir, "census3.sql"))
 	// get census3 goose migrations and setup for sqlite3
 	goose.SetDialect("sqlite3")
 	goose.SetBaseFS(migrationsFS)

--- a/state/web3.go
+++ b/state/web3.go
@@ -559,7 +559,7 @@ func (w *Web3) GetContractCreationBlock(ctx context.Context) (uint64, error) {
 func (w *Web3) getCreationBlock(ctx context.Context, start, end uint64) (uint64, error) {
 	// if both block numbers are equal, return its value as birthblock
 	if start == end {
-		return start, nil
+		return start - 1, nil
 	}
 	// find the middle block between start and end blocks and get the contract
 	// code at this block


### PR DESCRIPTION
This upgrade implements the calculation of the block number when the contract was deployed. 
Currently the calculation is done during the token creation API call, which means that if the calculation takes too long, the token will not be created and an error will be thrown.