### PR TITLE
Fix census id unique constrain

### DIFF
--- a/db/queries/censuses.sql
+++ b/db/queries/censuses.sql
@@ -41,9 +41,9 @@ JOIN token_types AS tt ON t.type_id = tt.id
 WHERE tt.type_name = ?;
 
 -- name: LastCensusID :one
-SELECT strategy_id 
+SELECT id 
 FROM censuses 
-ORDER BY strategy_id DESC
+ORDER BY id DESC
 LIMIT 1;
 
 -- name: CreateCensus :execresult

--- a/db/sqlc/censuses.sql.go
+++ b/db/sqlc/censuses.sql.go
@@ -294,17 +294,17 @@ func (q *Queries) DeleteCensusBlock(ctx context.Context, arg DeleteCensusBlockPa
 }
 
 const lastCensusID = `-- name: LastCensusID :one
-SELECT strategy_id 
+SELECT id 
 FROM censuses 
-ORDER BY strategy_id DESC
+ORDER BY id DESC
 LIMIT 1
 `
 
 func (q *Queries) LastCensusID(ctx context.Context) (int64, error) {
 	row := q.db.QueryRowContext(ctx, lastCensusID)
-	var strategy_id int64
-	err := row.Scan(&strategy_id)
-	return strategy_id, err
+	var id int64
+	err := row.Scan(&id)
+	return id, err
 }
 
 const listCensuses = `-- name: ListCensuses :many


### PR DESCRIPTION
This is a hotfix for the issue found by @emmdim regarding the creation of a new census.

The bug is caused by a wrong SQL query that tries to retrieve the last added census ID to increment it by one for the new census. The query gets the `strategy_id` column instead of the `id` and that's why the unique constraint was not fulfilled.

I also found and fixed another bug that return a wrong census ID when the user tries to create a new census with the same holders (and merkle root)