### PR TITLE
F/scan tweaks

### DIFF
--- a/service/const.go
+++ b/service/const.go
@@ -3,6 +3,9 @@ package service
 import "time"
 
 const (
-	snapshotBlocks = 100000           // a snapshot and reset of the tree is performed every snapshotBlocks
-	scanSleepTime  = time.Second * 60 // time to sleep between scans, 1 minute
+	snapshotBlocks        = 100000            // a snapshot and reset of the tree is performed every snapshotBlocks
+	scanSleepTime         = time.Second * 20  // time to sleep between scans
+	scanSleepTimeOnceSync = time.Second * 120 // time to sleep between scans, once all the tokens are synced
+	// scanIterationDurationPerToken is the time the scanner will spend scanning each token, by iteration.
+	scanIterationDurationPerToken = 60 * time.Second
 )

--- a/service/holder_scanner_test.go
+++ b/service/holder_scanner_test.go
@@ -171,7 +171,7 @@ func Test_scanHolders(t *testing.T) {
 	// token does not exists
 	ctx1, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	err = hs.scanHolders(ctx1, MonkeysAddress)
+	_, err = hs.scanHolders(ctx1, MonkeysAddress)
 	c.Assert(err, qt.IsNotNil)
 
 	_, err = testdb.queries.CreateToken(context.Background(), testTokenParams(
@@ -181,7 +181,8 @@ func Test_scanHolders(t *testing.T) {
 	// token exists and the scanner gets the holders
 	ctx2, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	c.Assert(hs.scanHolders(ctx2, MonkeysAddress), qt.IsNil)
+	_, err = hs.scanHolders(ctx2, MonkeysAddress)
+	c.Assert(err, qt.IsNil)
 
 	res, err := testdb.queries.TokenHoldersByTokenID(context.Background(), MonkeysAddress.Bytes())
 	c.Assert(err, qt.IsNil)

--- a/service/holders_scanner.go
+++ b/service/holders_scanner.go
@@ -101,7 +101,7 @@ func (s *HoldersScanner) Start(ctx context.Context) {
 			}
 			log.Infow("scan iteration finished",
 				"iteration", itCounter,
-				"duration", time.Since(startTime),
+				"duration", time.Since(startTime).Seconds(),
 				"atSync", atSyncGlobal)
 			if atSyncGlobal {
 				time.Sleep(scanSleepTimeOnceSync)

--- a/service/holders_scanner.go
+++ b/service/holders_scanner.go
@@ -66,12 +66,15 @@ func NewHoldersScanner(db *sql.DB, q *queries.Queries, w3uri string) (*HoldersSc
 // synchronised with the database instance.
 func (s *HoldersScanner) Start(ctx context.Context) {
 	// monitor for new tokens added and update every token holders
+	itCounter := uint64(0)
 	for {
 		select {
 		case <-ctx.Done():
 			log.Info(ErrHalted)
 			return
 		default:
+			itCounter++
+			startTime := time.Now()
 			// get updated list of tokens
 			tokens, err := s.tokenAddresses()
 			if err != nil {
@@ -79,6 +82,7 @@ func (s *HoldersScanner) Start(ctx context.Context) {
 				continue
 			}
 			// scan for new holders of every token
+			atSyncGlobal := true
 			for addr, ready := range tokens {
 				if !ready {
 					if err := s.calcTokenCreationBlock(ctx, addr); err != nil {
@@ -86,12 +90,24 @@ func (s *HoldersScanner) Start(ctx context.Context) {
 						continue
 					}
 				}
-				if err := s.scanHolders(ctx, addr); err != nil {
+				atSync, err := s.scanHolders(ctx, addr)
+				if err != nil {
 					log.Error(err)
+					continue
+				}
+				if !atSync {
+					atSyncGlobal = false
 				}
 			}
-			log.Info("waiting until next scan iteration")
-			time.Sleep(scanSleepTime)
+			log.Infow("scan iteration finished",
+				"iteration", itCounter,
+				"duration", time.Since(startTime),
+				"atSync", atSyncGlobal)
+			if atSyncGlobal {
+				time.Sleep(scanSleepTimeOnceSync)
+			} else {
+				time.Sleep(scanSleepTime)
+			}
 		}
 	}
 }
@@ -138,9 +154,7 @@ func (s *HoldersScanner) saveHolders(th *state.TokenHolders) error {
 		return err
 	}
 	defer func() {
-		if err := tx.Rollback(); err != nil {
-			log.Errorw(err, "holders transaction rollback failed")
-		}
+		_ = tx.Rollback()
 	}()
 	qtx := s.sqlc.WithTx(tx)
 	if exists, err := qtx.ExistsToken(ctx, th.Address().Bytes()); err != nil {
@@ -278,9 +292,9 @@ func (s *HoldersScanner) saveHolders(th *state.TokenHolders) error {
 // HoldersScanner database and caches it. If something expected fails or the
 // scan process ends successfully, the cached information is stored in the
 // database. If it has no updates, it does not change anything and returns nil.
-func (s *HoldersScanner) scanHolders(ctx context.Context, addr common.Address) error {
+func (s *HoldersScanner) scanHolders(ctx context.Context, addr common.Address) (bool, error) {
 	log.Debugf("scanning contract %s", addr)
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, scanIterationDurationPerToken)
 	defer cancel()
 	// get the token TokenHolders struct from cache, if it not exists it will
 	// be initialized
@@ -291,7 +305,7 @@ func (s *HoldersScanner) scanHolders(ctx context.Context, addr common.Address) e
 		// get token information from the database
 		tokenInfo, err := s.sqlc.TokenByID(ctx, addr.Bytes())
 		if err != nil {
-			return err
+			return false, err
 		}
 		ttype := state.TokenType(tokenInfo.TypeID)
 		tokenLastBlock := uint64(tokenInfo.CreationBlock.Int32)
@@ -311,15 +325,15 @@ func (s *HoldersScanner) scanHolders(ctx context.Context, addr common.Address) e
 	// init web3 contract state
 	w3 := state.Web3{}
 	if err := w3.Init(ctx, s.web3, addr, th.Type()); err != nil {
-		return err
+		return th.IsSynced(), err
 	}
 	// try to update the TokenHolders struct and the current scanner last block
-	var err error
-	if _, err = w3.UpdateTokenHolders(ctx, th); err != nil {
+	_, err := w3.UpdateTokenHolders(ctx, th)
+	if err != nil {
 		if strings.Contains(err.Error(), "no new blocks") {
 			// if no new blocks error raises, log it as debug and return nil
 			log.Debugw("no new blocks to scan", "token", th.Address())
-			return nil
+			return true, nil
 		}
 		if strings.Contains(err.Error(), "connection reset") ||
 			strings.Contains(err.Error(), "context deadline") ||
@@ -330,15 +344,15 @@ func (s *HoldersScanner) scanHolders(ctx context.Context, addr common.Address) e
 			log.Warnw("warning scanning contract", "token", th.Address().Hex(),
 				"block", th.LastBlock(), "error", err)
 			// save TokesHolders state into the database before exit of the function
-			return s.saveHolders(th)
+			return th.IsSynced(), s.saveHolders(th)
 		}
 		// if unexpected error raises, log it as error and return it.
 		log.Error("warning scanning contract", "token", th.Address().Hex(),
 			"block", th.LastBlock(), "error", err)
-		return err
+		return th.IsSynced(), err
 	}
 	// save TokesHolders state into the database before exit of the function
-	return s.saveHolders(th)
+	return th.IsSynced(), s.saveHolders(th)
 }
 
 // calcTokenCreationBlock function attempts to calculate the block number when

--- a/state/const.go
+++ b/state/const.go
@@ -5,9 +5,9 @@ const timeLayout = "2006-01-02T15:04:05Z07:00"
 const (
 	// OTHER CONSTANTS
 	MAX_SCAN_BLOCKS_PER_ITERATION           = 1000000
-	MAX_SCAN_LOGS_PER_ITERATION             = 80000
+	MAX_SCAN_LOGS_PER_ITERATION             = 100000
 	MAX_NEW_HOLDER_CANDIDATES_PER_ITERATION = 5000
-	BLOCKS_TO_SCAN_AT_ONCE                  = uint64(5000)
+	BLOCKS_TO_SCAN_AT_ONCE                  = uint64(20000)
 	NULL_ADDRESS                            = "0"
 )
 

--- a/state/web3.go
+++ b/state/web3.go
@@ -332,8 +332,14 @@ func (w *Web3) UpdateTokenHolders(ctx context.Context, th *TokenHolders) (uint64
 			return fromBlockNumber, w.commitTokenHolders(th, holdersCandidates, th.LastBlock())
 		default:
 			startTime := time.Now()
-			log.Infof("analyzing blocks from %d to %d [%d%%]", fromBlockNumber,
-				fromBlockNumber+blocks, (fromBlockNumber*100)/toBlock)
+			log.Infow("analyzing blocks",
+				"address", th.Address().Hex(),
+				"type", th.Type(),
+				"from", fromBlockNumber,
+				"to", fromBlockNumber+blocks,
+				"progress", fmt.Sprintf("%d%%", (fromBlockNumber*100)/toBlock),
+			)
+
 			// get transfer logs for the following n blocks
 			logs, err := w.transferLogs(fromBlockNumber, blocks)
 			if err != nil {

--- a/state/web3.go
+++ b/state/web3.go
@@ -337,7 +337,6 @@ func (w *Web3) UpdateTokenHolders(ctx context.Context, th *TokenHolders) (uint64
 				"type", th.Type(),
 				"from", fromBlockNumber,
 				"to", fromBlockNumber+blocks,
-				"progress", fmt.Sprintf("%d%%", (fromBlockNumber*100)/toBlock),
 			)
 
 			// get transfer logs for the following n blocks
@@ -360,7 +359,6 @@ func (w *Web3) UpdateTokenHolders(ctx context.Context, th *TokenHolders) (uint64
 				continue
 			}
 			logCount += len(logs)
-			log.Infof("found %d logs, iteration count %d", len(logs), logCount)
 			blocksToSave := make(map[uint64]bool)
 			// iterate over the logs and update the token holders state
 			for _, currentLog := range logs {
@@ -381,8 +379,13 @@ func (w *Web3) UpdateTokenHolders(ctx context.Context, th *TokenHolders) (uint64
 				newBlocksMap[currentLog.BlockNumber] = true
 				th.BlockDone(currentLog.BlockNumber)
 			}
-			log.Debugf("saved %d blocks at %.2f blocks/second", len(blocksToSave),
-				1000*float32(len(blocksToSave))/float32(time.Since(startTime).Milliseconds()))
+			log.Debugw("saving blocks",
+				"count", len(blocksToSave),
+				"logs", logs,
+				"blocks/s", 1000*float32(len(blocksToSave))/float32(time.Since(startTime).Milliseconds()),
+				"took", time.Since(startTime).Seconds(),
+				"progress", fmt.Sprintf("%d%%", (fromBlockNumber*100)/toBlock))
+
 			// check if we need to exit because max logs reached for iteration
 			if len(holdersCandidates) > MAX_NEW_HOLDER_CANDIDATES_PER_ITERATION {
 				log.Debug("MAX_NEW_HOLDER_CANDIDATES_PER_ITERATION limit reached... stop scanning")

--- a/state/web3.go
+++ b/state/web3.go
@@ -381,7 +381,7 @@ func (w *Web3) UpdateTokenHolders(ctx context.Context, th *TokenHolders) (uint64
 			}
 			log.Debugw("saving blocks",
 				"count", len(blocksToSave),
-				"logs", logs,
+				"logs", len(logs),
 				"blocks/s", 1000*float32(len(blocksToSave))/float32(time.Since(startTime).Milliseconds()),
 				"took", time.Since(startTime).Seconds(),
 				"progress", fmt.Sprintf("%d%%", (fromBlockNumber*100)/toBlock))

--- a/state/web3.go
+++ b/state/web3.go
@@ -303,10 +303,10 @@ func (w *Web3) UpdateTokenHolders(ctx context.Context, th *TokenHolders) (uint64
 	if err != nil {
 		return 0, err
 	}
-	log.Debugf("last block number: %d", lastBlockNumber)
 	// check if there are new blocks to scan
 	toBlock := lastBlockNumber
 	fromBlockNumber := th.LastBlock()
+	initialBlockNumber := fromBlockNumber
 	if fromBlockNumber >= lastBlockNumber {
 		return fromBlockNumber, ErrNoNewBlocks
 	}
@@ -316,13 +316,18 @@ func (w *Web3) UpdateTokenHolders(ctx context.Context, th *TokenHolders) (uint64
 		toBlock = fromBlockNumber + MAX_SCAN_BLOCKS_PER_ITERATION
 	}
 	blocks := BLOCKS_TO_SCAN_AT_ONCE
-	log.Infof("start scan iteration for %s from block %d to %d", w.contractAddress.Hex(), fromBlockNumber, toBlock)
+	log.Infow("scan iteration",
+		"address", th.Address().Hex(),
+		"type", th.Type(),
+		"from", fromBlockNumber,
+		"to", toBlock)
 	// get logs and get new candidates to holder. A valid candidate is every
 	// address with a positive balance at the end of logs review. It requires
 	// take into account the countability of the candidates' balances.
 	logCount := 0
 	newBlocksMap := make(map[uint64]bool)
 	holdersCandidates := HoldersCandidates{}
+	startTime := time.Now()
 	for fromBlockNumber < toBlock {
 		select {
 		// check if we need to close due context signal
@@ -331,8 +336,7 @@ func (w *Web3) UpdateTokenHolders(ctx context.Context, th *TokenHolders) (uint64
 			th.BlockDone(fromBlockNumber)
 			return fromBlockNumber, w.commitTokenHolders(th, holdersCandidates, th.LastBlock())
 		default:
-			startTime := time.Now()
-			log.Infow("analyzing blocks",
+			log.Debugw("analyzing blocks",
 				"address", th.Address().Hex(),
 				"type", th.Type(),
 				"from", fromBlockNumber,
@@ -379,13 +383,6 @@ func (w *Web3) UpdateTokenHolders(ctx context.Context, th *TokenHolders) (uint64
 				newBlocksMap[currentLog.BlockNumber] = true
 				th.BlockDone(currentLog.BlockNumber)
 			}
-			log.Debugw("saving blocks",
-				"count", len(blocksToSave),
-				"logs", len(logs),
-				"blocks/s", 1000*float32(len(blocksToSave))/float32(time.Since(startTime).Milliseconds()),
-				"took", time.Since(startTime).Seconds(),
-				"progress", fmt.Sprintf("%d%%", (fromBlockNumber*100)/toBlock))
-
 			// check if we need to exit because max logs reached for iteration
 			if len(holdersCandidates) > MAX_NEW_HOLDER_CANDIDATES_PER_ITERATION {
 				log.Debug("MAX_NEW_HOLDER_CANDIDATES_PER_ITERATION limit reached... stop scanning")
@@ -401,9 +398,16 @@ func (w *Web3) UpdateTokenHolders(ctx context.Context, th *TokenHolders) (uint64
 	}
 	th.BlockDone(toBlock)
 	if fromBlockNumber >= lastBlockNumber {
-		log.Infow("token synced", "token", w.contractAddress.Hex())
+		log.Infow("token synced!", "token", w.contractAddress.Hex())
 		th.Synced()
 	}
+	log.Infow("saving blocks",
+		"count", len(holdersCandidates),
+		"logs", logCount,
+		"blocks/s", 1000*float32(fromBlockNumber-initialBlockNumber)/float32(time.Since(startTime).Milliseconds()),
+		"took", time.Since(startTime).Seconds(),
+		"progress", fmt.Sprintf("%d%%", (fromBlockNumber*100)/lastBlockNumber))
+
 	return toBlock, w.commitTokenHolders(th, holdersCandidates, toBlock)
 }
 

--- a/state/web3.go
+++ b/state/web3.go
@@ -318,7 +318,7 @@ func (w *Web3) UpdateTokenHolders(ctx context.Context, th *TokenHolders) (uint64
 	blocks := BLOCKS_TO_SCAN_AT_ONCE
 	log.Infow("scan iteration",
 		"address", th.Address().Hex(),
-		"type", th.Type(),
+		"type", th.Type().String(),
 		"from", fromBlockNumber,
 		"to", toBlock)
 	// get logs and get new candidates to holder. A valid candidate is every


### PR DESCRIPTION
Improve and reduce noise on log output.

The most important feature add on this PR is to introduce a second sleep time, depending on if all tokens are at sync (reached last available block on the current scan). So when we are syncing, it will iterate faster. When already sync, it will do it slower (thus reducing overhead and web3/rpc queries).

I'll squash the commits.