### PR TITLE
new errors and API documentation

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -77,6 +77,7 @@ Triggers a new scan for the provided token, starting from the defined block.
 | HTTP Status  | Message | Internal error |
 |:---:|:---|:---:|
 | 400 | `malformed token information` | 4000 | 
+| 409 | `token already created` | 4009 | 
 | 500 | `the token cannot be created` | 5000 | 
 | 500 | `error getting token information` | 5004 | 
 | 500 | `error initialising web3 client` | 5018 | 
@@ -114,6 +115,7 @@ Returns the information about the token referenced by the provided ID.
 | 404 | `no token found` | 4003 |
 | 500 | `error getting token information` | 5004 | 
 | 500 | `error initialising web3 client` | 5018 | 
+| 500 | `error getting last block number from web3 endpoint` | 5021 | 
 | 500 | `error encoding tokens` | 5011 | 
 
 **MVP Warn**: If `defaultStrategy` is `0`, no strategy (neither the dummy strategy) is associated to the given token.

--- a/api/censuses.go
+++ b/api/censuses.go
@@ -42,7 +42,7 @@ func (capi *census3API) getCensus(msg *api.APIdata, ctx *httprouter.HTTPContext)
 	// begin a transaction for group sql queries
 	tx, err := capi.db.BeginTx(internalCtx, nil)
 	if err != nil {
-		return err
+		return ErrCantGetCensus
 	}
 	defer func() {
 		if err := tx.Rollback(); err != nil {
@@ -96,7 +96,7 @@ func (capi *census3API) createAndPublishCensus(msg *api.APIdata, ctx *httprouter
 	// begin a transaction for group sql queries
 	tx, err := capi.db.BeginTx(internalCtx, nil)
 	if err != nil {
-		return err
+		return ErrCantCreateCensus
 	}
 	defer func() {
 		if err := tx.Rollback(); err != nil {

--- a/api/errors.go
+++ b/api/errors.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"fmt"
+	"net/http"
 
 	"go.vocdoni.io/dvote/httprouter/apirest"
 )
@@ -51,6 +52,11 @@ var (
 		Code:       4008,
 		HTTPstatus: apirest.HTTPstatusNoContent,
 		Err:        fmt.Errorf("no strategy found"),
+	}
+	ErrTokenAlreadyExists = apirest.APIerror{
+		Code:       4009,
+		HTTPstatus: http.StatusConflict,
+		Err:        fmt.Errorf("token already created"),
 	}
 	ErrCantCreateToken = apirest.APIerror{
 		Code:       5000,
@@ -156,5 +162,10 @@ var (
 		Code:       5020,
 		HTTPstatus: apirest.HTTPstatusInternalErr,
 		Err:        fmt.Errorf("error counting census size"),
+	}
+	ErrCantGetLastBlockNumber = apirest.APIerror{
+		Code:       5021,
+		HTTPstatus: apirest.HTTPstatusInternalErr,
+		Err:        fmt.Errorf("error getting last block number from web3 endpoint"),
 	}
 )


### PR DESCRIPTION
All errors returned by the API reviewed creating two new errors:
* POST `/token` now returns a `409 - token already created` if the requested token already exists in the database.
* GET `/token/{tokenID}` now returns a `500 - error getting last block number from web3 endpoint` if the initialization of Web3 services works but it can't get the last block number

All this changes are documented on the [updated API specification](https://github.com/vocdoni/census3/blob/8a940c840d5b2b2a30e728c1ce82f8e17ad38a6f/api/README.md)