### PR TITLE
feature: limit token creation endpoint

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -17,6 +17,7 @@ type Census3APIConf struct {
 	DataDir       string
 	GroupKey      string
 	Web3Providers map[uint64]string
+	AdminToken    string
 }
 
 type census3API struct {
@@ -48,6 +49,8 @@ func Init(db *db.DB, conf Census3APIConf) error {
 	if newAPI.endpoint, err = api.NewAPI(&r, "/api"); err != nil {
 		return err
 	}
+	// set the admin token
+	newAPI.endpoint.SetAdminToken(conf.AdminToken)
 	// init the census DB
 	if newAPI.censusDB, err = census.NewCensusDB(conf.DataDir, conf.GroupKey); err != nil {
 		return err

--- a/api/tokens.go
+++ b/api/tokens.go
@@ -22,7 +22,7 @@ func (capi *census3API) initTokenHandlers() error {
 		return err
 	}
 	if err := capi.endpoint.RegisterMethod("/tokens", "POST",
-		api.MethodAccessTypePublic, capi.createToken); err != nil {
+		api.MethodAccessTypeAdmin, capi.createToken); err != nil {
 		return err
 	}
 	if err := capi.endpoint.RegisterMethod("/tokens/{tokenID}", "GET",


### PR DESCRIPTION
limiting POST /tokens endpoint to admins, the admint auth token can be defined as flag or in the env file, if it is not defined, it is randomly generated and logged