### PR TITLE
bug: ci github actions web3 uri

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,9 +46,13 @@ jobs:
             exit 1
           fi
       - name: Run Go test
+        env: 
+          WEB3_URI: ${{ secrets.WEB3_URI }}
         run: go test ./...
       - name: Run Go test -race
         if: github.ref == 'refs/heads/stage' ||  startsWith(github.ref, 'refs/heads/release')
+        env: 
+          WEB3_URI: ${{ secrets.WEB3_URI }}
         run: go test -vet=off -timeout=15m -race ./... # note that -race can easily make the crypto stuff 10x slower
 
   docker-release:


### PR DESCRIPTION
fixing github action to use the correct secret for valid Web3 URI for the CI