### PR TITLE
bug: old null columns issue with new migration

### DIFF
--- a/db/migrations/0001_census3.sql
+++ b/db/migrations/0001_census3.sql
@@ -25,7 +25,7 @@ CREATE TABLE tokens (
     creation_block BIGINT,
     type_id INTEGER NOT NULL,
     synced BOOLEAN NOT NULL,
-    tags TEXT,
+    tag TEXT,
     chain_id INTEGER NOT NULL,
     UNIQUE (id, chain_id),
     FOREIGN KEY (type_id) REFERENCES token_types(id) ON DELETE CASCADE
@@ -82,7 +82,19 @@ CREATE TABLE strategy_tokens (
 CREATE INDEX idx_strategy_tokens_strategy_id ON strategy_tokens(strategy_id);
 CREATE INDEX idx_strategy_tokens_token_id ON strategy_tokens(token_id);
 
+CREATE TABLE census_blocks (
+    census_id INTEGER NOT NULL,
+    block_id INTEGER NOT NULL,
+    PRIMARY KEY (census_id, block_id),
+    FOREIGN KEY (census_id) REFERENCES censuses(id) ON DELETE CASCADE,
+    FOREIGN KEY (block_id) REFERENCES blocks(id) ON DELETE CASCADE
+);
+CREATE INDEX idx_census_blocks_census_id ON census_blocks(census_id);
+CREATE INDEX idx_census_blocks_block_id ON census_blocks(block_id);
+
 -- +goose Down
+DROP INDEX IF EXISTS idx_census_blocks_block_id;
+DROP INDEX IF EXISTS idx_census_blocks_census_id;
 DROP INDEX IF EXISTS idx_strategy_tokens_token_id;
 DROP INDEX IF EXISTS idx_strategy_tokens_strategy_id;
 DROP INDEX IF EXISTS idx_token_holders_block_id;
@@ -91,6 +103,7 @@ DROP INDEX IF EXISTS idx_token_holders_token_id;
 DROP INDEX IF EXISTS idx_censuses_strategy_id;
 DROP INDEX IF EXISTS idx_tokens_type_id;
 
+DROP TABLE IF EXISTS census_blocks;
 DROP TABLE IF EXISTS strategy_tokens;
 DROP TABLE IF EXISTS token_holders;
 DROP TABLE IF EXISTS holders;

--- a/db/migrations/0002_census3.sql
+++ b/db/migrations/0002_census3.sql
@@ -1,8 +1,17 @@
 -- +goose Up
 
 -- tokens table schema updates
-ALTER TABLE tokens ADD COLUMN chain_address TEXT;
-ALTER TABLE tokens ADD COLUMN external_id TEXT;
+ALTER TABLE tokens ADD COLUMN chain_address TEXT NOT NULL DEFAULT '';
+ALTER TABLE tokens ADD COLUMN external_id TEXT NOT NULL DEFAULT '';
+ALTER TABLE tokens RENAME COLUMN tag TO tags;
+UPDATE tokens SET name = '' WHERE name IS NULL;
+UPDATE tokens SET symbol = '' WHERE symbol IS NULL;
+UPDATE tokens SET decimals = 0 WHERE decimals IS NULL;
+UPDATE tokens SET total_supply = '' WHERE total_supply IS NULL;
+UPDATE tokens SET creation_block = 0 WHERE creation_block IS NULL;
+UPDATE tokens SET tags = '' WHERE tags IS NULL;
+UPDATE tokens SET chain_address = '' WHERE chain_address IS NULL;
+UPDATE tokens SET external_id = '' WHERE external_id IS NULL;
 CREATE TABLE tokens_copy (
     id BLOB NOT NULL,
     name TEXT NOT NULL DEFAULT '',
@@ -26,8 +35,8 @@ ALTER TABLE tokens_copy RENAME TO tokens;
 CREATE INDEX idx_tokens_type_id ON tokens(type_id);
 
 -- token_holders table schema updates
-ALTER TABLE token_holders ADD COLUMN chain_id INTEGER;
-ALTER TABLE token_holders ADD COLUMN external_id TEXT;
+ALTER TABLE token_holders ADD COLUMN chain_id INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE token_holders ADD COLUMN external_id TEXT NOT NULL DEFAULT '';
 CREATE TABLE token_holders_copy (
     token_id BLOB NOT NULL,
     holder_id BLOB NOT NULL,
@@ -59,7 +68,7 @@ CREATE INDEX idx_token_holders_block_id ON token_holders(block_id);
 ALTER TABLE strategies ADD COLUMN alias TEXT NOT NULL DEFAULT '';
 ALTER TABLE strategies ADD COLUMN uri TEXT NOT NULL DEFAULT '';
 
-ALTER TABLE strategy_tokens ADD COLUMN external_id BLOB;
+ALTER TABLE strategy_tokens ADD COLUMN external_id BLOB NOT NULL DEFAULT '';
 -- strategy tokens schema updates
 CREATE TABLE strategy_tokens_copy (
     strategy_id INTEGER NOT NULL,
@@ -67,7 +76,7 @@ CREATE TABLE strategy_tokens_copy (
     min_balance BLOB NOT NULL,
     chain_id INTEGER NOT NULL,
     external_id TEXT NOT NULL DEFAULT '',
-    PRIMARY KEY (strategy_id, token_id, external_id),
+    PRIMARY KEY (strategy_id, token_id, chain_id, external_id),
     FOREIGN KEY (strategy_id) REFERENCES strategies(id) ON DELETE CASCADE,
     FOREIGN KEY (token_id) REFERENCES tokens(id) ON DELETE CASCADE
 );


### PR DESCRIPTION
Columns that accepted null values in stage and dev no longer do so in new migration versions.

To avoid errors, we need to update these columns with a default value before copying them.