### PR TITLE
bug: missing `defaultStrategy` token attribute

### DIFF
--- a/db/migrations/0002_census3.sql
+++ b/db/migrations/0002_census3.sql
@@ -16,10 +16,17 @@ CREATE TABLE tokens_copy (
     chain_id INTEGER NOT NULL DEFAULT 0,
     chain_address TEXT NOT NULL DEFAULT '',
     external_id TEXT NULL DEFAULT '',
+    default_strategy INTEGER NOT NULL DEFAULT 0,
     PRIMARY KEY (id, chain_id, external_id),
-    FOREIGN KEY (type_id) REFERENCES token_types(id) ON DELETE CASCADE
+    FOREIGN KEY (type_id) REFERENCES token_types(id) ON DELETE CASCADE,
+    FOREIGN KEY (default_strategy) REFERENCES strategies(id) ON DELETE CASCADE
 );
-INSERT INTO tokens_copy SELECT * FROM tokens;
+INSERT INTO tokens_copy (id, name, symbol, decimals, total_supply, creation_block, type_id, synced, tags, chain_id, chain_address, external_id, default_strategy) 
+SELECT * FROM (
+    SELECT id, name, symbol, decimals, total_supply, creation_block, type_id, synced, tags, chain_id, chain_address, external_id, (
+        SELECT strategy_id FROM strategy_tokens WHERE token_id = tokens.id AND strategy_tokens.chain_id = tokens.chain_id AND strategy_tokens.external_id = tokens.external_id LIMIT 1
+    ) AS default_strategy FROM tokens
+);
 DROP TABLE tokens;
 -- DROP INDEX IF EXISTS idx_tokens_type_id;
 ALTER TABLE tokens_copy RENAME TO tokens;

--- a/db/queries/tokens.sql
+++ b/db/queries/tokens.sql
@@ -51,10 +51,11 @@ INSERT INTO tokens (
     tags,
     chain_id,
     chain_address,
-    external_id
+    external_id,
+    default_strategy
 )
 VALUES (
-    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0
 );
 
 -- name: UpdateTokenStatus :execresult
@@ -69,6 +70,13 @@ WHERE id = sqlc.arg(id)
 UPDATE tokens
 SET creation_block = sqlc.arg(creation_block)
 WHERE id = sqlc.arg(id);
+
+-- name: UpdateTokenDefaultStrategy :execresult
+UPDATE tokens
+SET default_strategy = sqlc.arg(default_strategy)
+WHERE id = sqlc.arg(id)
+    AND chain_id = sqlc.arg(chain_id)
+    AND external_id = sqlc.arg(external_id);
 
 -- name: ExistsToken :one
 SELECT EXISTS 

--- a/db/sqlc/holders.sql.go
+++ b/db/sqlc/holders.sql.go
@@ -588,7 +588,7 @@ func (q *Queries) TokenHoldersByTokenIDAndExternalID(ctx context.Context, arg To
 }
 
 const tokensByHolderID = `-- name: TokensByHolderID :many
-SELECT tokens.id, tokens.name, tokens.symbol, tokens.decimals, tokens.total_supply, tokens.creation_block, tokens.type_id, tokens.synced, tokens.tags, tokens.chain_id, tokens.chain_address, tokens.external_id
+SELECT tokens.id, tokens.name, tokens.symbol, tokens.decimals, tokens.total_supply, tokens.creation_block, tokens.type_id, tokens.synced, tokens.tags, tokens.chain_id, tokens.chain_address, tokens.external_id, tokens.default_strategy
 FROM tokens
 JOIN token_holders ON tokens.id = token_holders.token_id
 WHERE token_holders.holder_id = ?
@@ -616,6 +616,7 @@ func (q *Queries) TokensByHolderID(ctx context.Context, holderID annotations.Add
 			&i.ChainID,
 			&i.ChainAddress,
 			&i.ExternalID,
+			&i.DefaultStrategy,
 		); err != nil {
 			return nil, err
 		}

--- a/db/sqlc/models.go
+++ b/db/sqlc/models.go
@@ -47,18 +47,19 @@ type StrategyToken struct {
 }
 
 type Token struct {
-	ID            annotations.Address
-	Name          string
-	Symbol        string
-	Decimals      uint64
-	TotalSupply   annotations.BigInt
-	CreationBlock int64
-	TypeID        uint64
-	Synced        bool
-	Tags          string
-	ChainID       uint64
-	ChainAddress  string
-	ExternalID    string
+	ID              annotations.Address
+	Name            string
+	Symbol          string
+	Decimals        uint64
+	TotalSupply     annotations.BigInt
+	CreationBlock   int64
+	TypeID          uint64
+	Synced          bool
+	Tags            string
+	ChainID         uint64
+	ChainAddress    string
+	ExternalID      string
+	DefaultStrategy uint64
 }
 
 type TokenHolder struct {


### PR DESCRIPTION
After new strategies merge, we missing to assign the default strategy created during a token creation to the new token.

This PR includes:
* A new `default_strategy` column on tokens table.
* A foreign key to this new column to the strategies table.
* A mechanism to update the token during its creation to include the default strategy id created.
* A updated to the migrations to get the default strategy from strategies table (it fails but is fixed on #111).