### PR TITLE
bug: no token size

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -74,6 +74,8 @@ List of already added tokens.
             "name": "Wrapped Aragon Network Token",
             "type": "erc20|erc721|erc777|erc1155|nation3|wANT",
             "startBlock": 123456,
+            "size": 100,
+            "decimals": 18,
             "symbol": "wANT",
             "tags": "testTag1,testTag2",
             "chainID": 1,
@@ -170,6 +172,7 @@ Returns the information about the token referenced by the provided ID and chain 
 {
     "ID": "0x1324",
     "type": "erc20",
+    "size": 120,
     "decimals": 18,
     "startBlock": 123456,
     "symbol": "$",

--- a/db/queries/holders.sql
+++ b/db/queries/holders.sql
@@ -66,10 +66,12 @@ WHERE token_id = ?
 ORDER BY block_id DESC
 LIMIT 1;
 
--- name: CountTokenHoldersByTokenID :one
+-- name: CountTokenHolders :one
 SELECT COUNT(holder_id) 
 FROM token_holders
-WHERE token_id = ?;
+WHERE token_id = ?
+    AND chain_id = ?
+    AND external_id = ?;
 
 -- name: CreateTokenHolder :execresult
 INSERT INTO token_holders (

--- a/db/sqlc/holders.sql.go
+++ b/db/sqlc/holders.sql.go
@@ -77,14 +77,22 @@ func (q *Queries) ANDOperator(ctx context.Context, arg ANDOperatorParams) ([]AND
 	return items, nil
 }
 
-const countTokenHoldersByTokenID = `-- name: CountTokenHoldersByTokenID :one
+const countTokenHolders = `-- name: CountTokenHolders :one
 SELECT COUNT(holder_id) 
 FROM token_holders
 WHERE token_id = ?
+    AND chain_id = ?
+    AND external_id = ?
 `
 
-func (q *Queries) CountTokenHoldersByTokenID(ctx context.Context, tokenID annotations.Address) (int64, error) {
-	row := q.db.QueryRowContext(ctx, countTokenHoldersByTokenID, tokenID)
+type CountTokenHoldersParams struct {
+	TokenID    annotations.Address
+	ChainID    uint64
+	ExternalID string
+}
+
+func (q *Queries) CountTokenHolders(ctx context.Context, arg CountTokenHoldersParams) (int64, error) {
+	row := q.db.QueryRowContext(ctx, countTokenHolders, arg.TokenID, arg.ChainID, arg.ExternalID)
 	var count int64
 	err := row.Scan(&count)
 	return count, err


### PR DESCRIPTION
This PR fixes the bug of missing size (in POAP tokens) in both api tokens `GET /tokens` and `GET /tokens/{id}` including them.