### PR TITLE
feature: parametrize web3 endpoint cooldown to decrease it

### DIFF
--- a/example.env
+++ b/example.env
@@ -13,3 +13,5 @@ CENSUS3_LOGLEVEL=debug
 CENSUS3_CONNECTKEY=census3key
 # Internal data folder
 CENSUS3_DATADIR="./.census3"
+# Scanner cooldown duration
+CENSUS3_SCANNERCOOLDOWN="20s"

--- a/service/holder_scanner_test.go
+++ b/service/holder_scanner_test.go
@@ -25,7 +25,7 @@ func TestNewHolderScanner(t *testing.T) {
 	w3p, err := state.CheckWeb3Providers([]string{web3uri})
 	c.Assert(err, qt.IsNil)
 
-	hs, err := NewHoldersScanner(testdb.db, w3p, nil)
+	hs, err := NewHoldersScanner(testdb.db, w3p, nil, 20)
 	c.Assert(err, qt.IsNil)
 	c.Assert(hs.lastBlock, qt.Equals, uint64(0))
 
@@ -38,11 +38,11 @@ func TestNewHolderScanner(t *testing.T) {
 	})
 	c.Assert(err, qt.IsNil)
 
-	hs, err = NewHoldersScanner(testdb.db, w3p, nil)
+	hs, err = NewHoldersScanner(testdb.db, w3p, nil, 20)
 	c.Assert(err, qt.IsNil)
 	c.Assert(hs.lastBlock, qt.Equals, uint64(1000))
 
-	_, err = NewHoldersScanner(nil, w3p, nil)
+	_, err = NewHoldersScanner(nil, w3p, nil, 20)
 	c.Assert(err, qt.IsNotNil)
 }
 
@@ -58,7 +58,7 @@ func TestHolderScannerStart(t *testing.T) {
 	defer testdb.Close(t)
 
 	twg.Add(1)
-	hs, err := NewHoldersScanner(testdb.db, w3p, nil)
+	hs, err := NewHoldersScanner(testdb.db, w3p, nil, 20)
 	c.Assert(err, qt.IsNil)
 	go func() {
 		hs.Start(ctx)
@@ -78,7 +78,7 @@ func Test_tokenAddresses(t *testing.T) {
 	w3p, err := state.CheckWeb3Providers([]string{web3uri})
 	c.Assert(err, qt.IsNil)
 
-	hs, err := NewHoldersScanner(testdb.db, w3p, nil)
+	hs, err := NewHoldersScanner(testdb.db, w3p, nil, 20)
 	c.Assert(err, qt.IsNil)
 
 	res, err := hs.tokenAddresses()
@@ -117,7 +117,7 @@ func Test_saveHolders(t *testing.T) {
 	w3p, err := state.CheckWeb3Providers([]string{web3uri})
 	c.Assert(err, qt.IsNil)
 
-	hs, err := NewHoldersScanner(testdb.db, w3p, nil)
+	hs, err := NewHoldersScanner(testdb.db, w3p, nil, 20)
 	c.Assert(err, qt.IsNil)
 
 	th := new(state.TokenHolders).Init(MonkeysAddress, state.CONTRACT_TYPE_ERC20, MonkeysCreationBlock, 5, "")
@@ -177,7 +177,7 @@ func Test_scanHolders(t *testing.T) {
 	w3p, err := state.CheckWeb3Providers([]string{web3uri})
 	c.Assert(err, qt.IsNil)
 
-	hs, err := NewHoldersScanner(testdb.db, w3p, nil)
+	hs, err := NewHoldersScanner(testdb.db, w3p, nil, 20)
 	c.Assert(err, qt.IsNil)
 
 	// token does not exists
@@ -214,7 +214,7 @@ func Test_calcTokenCreationBlock(t *testing.T) {
 	w3p, err := state.CheckWeb3Providers([]string{web3uri})
 	c.Assert(err, qt.IsNil)
 
-	hs, err := NewHoldersScanner(testdb.db, w3p, nil)
+	hs, err := NewHoldersScanner(testdb.db, w3p, nil, 20)
 	c.Assert(err, qt.IsNil)
 	c.Assert(hs.calcTokenCreationBlock(context.Background(), MonkeysAddress, 5), qt.IsNotNil)
 

--- a/service/holders_scanner.go
+++ b/service/holders_scanner.go
@@ -36,12 +36,13 @@ type HoldersScanner struct {
 	db           *db.DB
 	lastBlock    uint64
 	extProviders map[state.TokenType]HolderProvider
+	coolDown     time.Duration
 }
 
 // NewHoldersScanner function creates a new HolderScanner using the dataDir path
 // and the web3 endpoint URI provided. It sets up a sqlite3 database instance
 // and gets the number of last block scanned from it.
-func NewHoldersScanner(db *db.DB, w3p state.Web3Providers, ext map[state.TokenType]HolderProvider) (*HoldersScanner, error) {
+func NewHoldersScanner(db *db.DB, w3p state.Web3Providers, ext map[state.TokenType]HolderProvider, coolDown time.Duration) (*HoldersScanner, error) {
 	if db == nil {
 		return nil, ErrNoDB
 	}
@@ -51,6 +52,7 @@ func NewHoldersScanner(db *db.DB, w3p state.Web3Providers, ext map[state.TokenTy
 		tokens:       []*state.TokenHolders{},
 		db:           db,
 		extProviders: ext,
+		coolDown:     coolDown,
 	}
 	// get latest analyzed block
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -106,7 +108,7 @@ func (s *HoldersScanner) Start(ctx context.Context) {
 				"duration", time.Since(startTime).Seconds(),
 				"atSync", atSyncGlobal)
 			if atSyncGlobal {
-				time.Sleep(scanSleepTimeOnceSync)
+				time.Sleep(s.coolDown)
 			} else {
 				time.Sleep(scanSleepTime)
 			}

--- a/service/holders_scanner.go
+++ b/service/holders_scanner.go
@@ -42,7 +42,9 @@ type HoldersScanner struct {
 // NewHoldersScanner function creates a new HolderScanner using the dataDir path
 // and the web3 endpoint URI provided. It sets up a sqlite3 database instance
 // and gets the number of last block scanned from it.
-func NewHoldersScanner(db *db.DB, w3p state.Web3Providers, ext map[state.TokenType]HolderProvider, coolDown time.Duration) (*HoldersScanner, error) {
+func NewHoldersScanner(db *db.DB, w3p state.Web3Providers,
+	ext map[state.TokenType]HolderProvider, coolDown time.Duration,
+) (*HoldersScanner, error) {
 	if db == nil {
 		return nil, ErrNoDB
 	}


### PR DESCRIPTION
#119 It creates new flag and env var to define the cool down time to start a new scanner iteration, by default 120s