### PR TITLE
bug: creation block on gnosis chain

### DIFF
--- a/service/holders_scanner.go
+++ b/service/holders_scanner.go
@@ -155,15 +155,6 @@ func (s *HoldersScanner) tokenAddresses() ([]scanToken, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	for _, token := range tokens {
-		log.Infow("unsorted token",
-			"token", token.ID,
-			"chainID", token.ChainID,
-			"lastBlock", token.LastBlock,
-			"currentChainBlock", currentBlockNumbers[token.ChainID],
-		)
-	}
 	// sort tokens by nearest to be synced, that is, the tokens that have the
 	// minimum difference between the current block of its chain and the last
 	// block scanned by the scanner (retrieved from the database as LastBlock)
@@ -180,14 +171,6 @@ func (s *HoldersScanner) tokenAddresses() ([]scanToken, error) {
 		jBlocksReamining := currentBlockNumbers[tokens[j].ChainID] - uint64(jLastBlock)
 		return iBlocksReamining < jBlocksReamining
 	})
-	for _, token := range tokens {
-		log.Infow("sorted token",
-			"token", token.ID,
-			"chainID", token.ChainID,
-			"lastBlock", token.LastBlock,
-			"currentChainBlock", currentBlockNumbers[token.ChainID],
-		)
-	}
 
 	// parse and return token addresses
 	results := []scanToken{}


### PR DESCRIPTION
Fixing error calculating birth block of gnosis tokens:
 * Handling specific error from gnosis, it returns an error when `CodeAt` is called on a block where the contract is not deployed yet.
 * Removing specific code for gnosis chain to calculate last block number, it is no longer required.
 * Removing debug prints.