### PR TITLE
feature: scan last tokens first

### DIFF
--- a/db/migrations/0003_census3.sql
+++ b/db/migrations/0003_census3.sql
@@ -1,0 +1,28 @@
+-- +goose Up
+
+-- add created_at column to tokens table
+CREATE TABLE tokens_copy (
+    id BLOB NOT NULL,
+    name TEXT NOT NULL DEFAULT '',
+    symbol TEXT NOT NULL DEFAULT '',
+    decimals INTEGER NOT NULL DEFAULT 0,
+    total_supply BLOB NOT NULL DEFAULT '',
+    creation_block BIGINT NOT NULL DEFAULT 0,
+    type_id INTEGER NOT NULL DEFAULT 0,
+    synced BOOLEAN NOT NULL DEFAULT 0,
+    tags TEXT NOT NULL DEFAULT '',
+    chain_id INTEGER NOT NULL DEFAULT 0,
+    chain_address TEXT NOT NULL DEFAULT '',
+    external_id TEXT NULL DEFAULT '',
+    default_strategy INTEGER NOT NULL DEFAULT 0,
+    icon_uri TEXT NOT NULL DEFAULT '',
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (id, chain_id, external_id),
+    FOREIGN KEY (type_id) REFERENCES token_types(id) ON DELETE CASCADE,
+    FOREIGN KEY (default_strategy) REFERENCES strategies(id) ON DELETE CASCADE
+);
+INSERT INTO tokens_copy (id, name, symbol, decimals, total_supply, creation_block, type_id, synced, tags, chain_id, chain_address, external_id, default_strategy, icon_uri)
+SELECT * FROM tokens;
+DROP TABLE tokens;
+ALTER TABLE tokens_copy RENAME TO tokens;
+CREATE INDEX idx_tokens_type_id ON tokens(type_id);

--- a/db/queries/tokens.sql
+++ b/db/queries/tokens.sql
@@ -1,11 +1,22 @@
--- name: ListTokens :many
+-- name: ListLastNoSyncedTokens :many
+SELECT * FROM tokens 
+WHERE strftime('%s', 'now') - strftime('%s', created_at) <= 600
+    AND synced = 0
+ORDER BY created_at DESC;
+
+-- name: ListOldNoSyncedTokens :many
 SELECT tokens.*, (
     SELECT MAX(block_id) AS last_block
     FROM token_holders
     WHERE token_id = tokens.id 
         AND chain_id = tokens.chain_id 
         AND external_id = tokens.external_id
-) FROM tokens;
+) FROM tokens 
+WHERE strftime('%s', 'now') - strftime('%s', created_at) > 600
+    AND synced = 0;
+
+-- name: ListSyncedTokens :many
+SELECT * FROM tokens WHERE synced = 1;
 
 -- name: NextTokensPage :many
 SELECT * FROM tokens

--- a/db/sqlc/holders.sql.go
+++ b/db/sqlc/holders.sql.go
@@ -644,7 +644,7 @@ func (q *Queries) TokenHoldersByTokenIDAndExternalID(ctx context.Context, arg To
 }
 
 const tokensByHolderID = `-- name: TokensByHolderID :many
-SELECT tokens.id, tokens.name, tokens.symbol, tokens.decimals, tokens.total_supply, tokens.creation_block, tokens.type_id, tokens.synced, tokens.tags, tokens.chain_id, tokens.chain_address, tokens.external_id, tokens.default_strategy, tokens.icon_uri
+SELECT tokens.id, tokens.name, tokens.symbol, tokens.decimals, tokens.total_supply, tokens.creation_block, tokens.type_id, tokens.synced, tokens.tags, tokens.chain_id, tokens.chain_address, tokens.external_id, tokens.default_strategy, tokens.icon_uri, tokens.created_at
 FROM tokens
 JOIN token_holders ON tokens.id = token_holders.token_id
 WHERE token_holders.holder_id = ?
@@ -674,6 +674,7 @@ func (q *Queries) TokensByHolderID(ctx context.Context, holderID annotations.Add
 			&i.ExternalID,
 			&i.DefaultStrategy,
 			&i.IconUri,
+			&i.CreatedAt,
 		); err != nil {
 			return nil, err
 		}

--- a/db/sqlc/models.go
+++ b/db/sqlc/models.go
@@ -6,6 +6,7 @@ package queries
 
 import (
 	"database/sql"
+	"time"
 
 	"github.com/vocdoni/census3/db/annotations"
 )
@@ -66,6 +67,7 @@ type Token struct {
 	ExternalID      string
 	DefaultStrategy uint64
 	IconUri         string
+	CreatedAt       time.Time
 }
 
 type TokenHolder struct {


### PR DESCRIPTION
tokens are created with its creation time associated, the scanner iterates over last created (less than 60 minutes) and not synced tokens, then the old not synced tokens (more than 60 minutes) and then the synced tokens.