### PR TITLE
Fix/token deletion bug

### DIFF
--- a/service/holder_scanner_test.go
+++ b/service/holder_scanner_test.go
@@ -205,7 +205,7 @@ func Test_calcTokenCreationBlock(t *testing.T) {
 	hs, err := NewHoldersScanner(testdb.db, web3Endpoints, nil, 20)
 	hs.tokens = append(hs.tokens, new(state.TokenHolders).Init(MonkeysAddress, state.CONTRACT_TYPE_ERC20, 0, 5, ""))
 	c.Assert(err, qt.IsNil)
-	c.Assert(hs.calcTokenCreationBlock(context.Background(), 05), qt.IsNotNil)
+	c.Assert(hs.calcTokenCreationBlock(context.Background(), 5), qt.IsNotNil)
 
 	_, err = testdb.db.QueriesRW.CreateToken(context.Background(), testTokenParams(
 		MonkeysAddress.String(), MonkeysName, MonkeysSymbol, MonkeysCreationBlock,

--- a/service/holder_scanner_test.go
+++ b/service/holder_scanner_test.go
@@ -69,7 +69,7 @@ func TestHolderScannerStart(t *testing.T) {
 	twg.Wait()
 }
 
-func Test_tokenAddresses(t *testing.T) {
+func Test_getTokensToScan(t *testing.T) {
 	c := qt.New(t)
 
 	testdb := StartTestDB(t)
@@ -77,10 +77,7 @@ func Test_tokenAddresses(t *testing.T) {
 
 	hs, err := NewHoldersScanner(testdb.db, web3Endpoints, nil, 20)
 	c.Assert(err, qt.IsNil)
-
-	res, err := hs.tokenAddresses()
-	c.Assert(err, qt.IsNil)
-	c.Assert(res, qt.HasLen, 0)
+	c.Assert(hs.getTokensToScan(), qt.IsNil)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -89,20 +86,20 @@ func Test_tokenAddresses(t *testing.T) {
 		MonkeysTotalSupply.Int64(), false, 5, ""))
 	c.Assert(err, qt.IsNil)
 
-	res, err = hs.tokenAddresses()
+	err = hs.getTokensToScan()
 	c.Assert(err, qt.IsNil)
-	c.Assert(res[0].ready, qt.IsFalse)
-	c.Assert(res[0].addr.String(), qt.Equals, common.HexToAddress("0x1").String())
+	c.Assert(hs.tokens[0].IsReady(), qt.IsFalse)
+	c.Assert(hs.tokens[0].Address().String(), qt.Equals, common.HexToAddress("0x1").String())
 
 	_, err = testdb.db.QueriesRW.CreateToken(ctx, testTokenParams("0x2", "test2",
 		"test3", 10, MonkeysDecimals, uint64(state.CONTRACT_TYPE_ERC20),
 		MonkeysTotalSupply.Int64(), false, 5, ""))
 	c.Assert(err, qt.IsNil)
 
-	res, err = hs.tokenAddresses()
+	err = hs.getTokensToScan()
 	c.Assert(err, qt.IsNil)
-	c.Assert(res[1].ready, qt.IsTrue)
-	c.Assert(res[1].addr.String(), qt.Equals, common.HexToAddress("0x2").String())
+	c.Assert(hs.tokens[1].IsReady(), qt.IsTrue)
+	c.Assert(hs.tokens[1].Address().String(), qt.Equals, common.HexToAddress("0x2").String())
 }
 
 func Test_saveHolders(t *testing.T) {
@@ -206,15 +203,16 @@ func Test_calcTokenCreationBlock(t *testing.T) {
 	defer testdb.Close(t)
 
 	hs, err := NewHoldersScanner(testdb.db, web3Endpoints, nil, 20)
+	hs.tokens = append(hs.tokens, new(state.TokenHolders).Init(MonkeysAddress, state.CONTRACT_TYPE_ERC20, 0, 5, ""))
 	c.Assert(err, qt.IsNil)
-	c.Assert(hs.calcTokenCreationBlock(context.Background(), MonkeysAddress, 5), qt.IsNotNil)
+	c.Assert(hs.calcTokenCreationBlock(context.Background(), 05), qt.IsNotNil)
 
 	_, err = testdb.db.QueriesRW.CreateToken(context.Background(), testTokenParams(
 		MonkeysAddress.String(), MonkeysName, MonkeysSymbol, MonkeysCreationBlock,
 		MonkeysDecimals, uint64(state.CONTRACT_TYPE_ERC20), MonkeysTotalSupply.Int64(), false, 5, ""))
 	c.Assert(err, qt.IsNil)
 
-	c.Assert(hs.calcTokenCreationBlock(context.Background(), MonkeysAddress, 5), qt.IsNil)
+	c.Assert(hs.calcTokenCreationBlock(context.Background(), 0), qt.IsNil)
 	token, err := testdb.db.QueriesRW.TokenByID(context.Background(), MonkeysAddress.Bytes())
 	c.Assert(err, qt.IsNil)
 	c.Assert(uint64(token.CreationBlock), qt.Equals, MonkeysCreationBlock)

--- a/state/holders.go
+++ b/state/holders.go
@@ -52,6 +52,13 @@ func (h *TokenHolders) Type() TokenType {
 	return h.ctype
 }
 
+// IsReady function returns if the given TokenHolders is ready to be scanned.
+// It means that the last block number is greater than 0, at least it will be
+// the creation block of the token.
+func (h *TokenHolders) IsReady() bool {
+	return h.lastBlock.Load() > 0
+}
+
 // Holders function returns the given TokenHolders current token holders
 // addresses and its balances.
 func (h *TokenHolders) Holders() HoldersCandidates {


### PR DESCRIPTION
Remove duplicate internal structure and get tokens to scan before each scanner loop iteration to ensure that deleted and re-created tokens are scanned from the beginning instead of the last block scanned after deletion.