### PR TITLE
Feature: Keep the total supply updated

### DIFF
--- a/api/tokens.go
+++ b/api/tokens.go
@@ -125,6 +125,7 @@ func (capi *census3API) getTokens(msg *api.APIdata, ctx *httprouter.HTTPContext)
 			ExternalID:      tokenData.ExternalID,
 			Synced:          tokenData.Synced,
 			DefaultStrategy: tokenData.DefaultStrategy,
+			TotalSupply:     string(tokenData.TotalSupply),
 			IconURI:         tokenData.IconUri,
 		})
 	}

--- a/db/queries/tokens.sql
+++ b/db/queries/tokens.sql
@@ -62,7 +62,8 @@ VALUES (
 UPDATE tokens
 SET synced = sqlc.arg(synced), 
     last_block = sqlc.arg(last_block),
-    analysed_transfers = sqlc.arg(analysed_transfers)
+    analysed_transfers = sqlc.arg(analysed_transfers),
+    total_supply = sqlc.arg(total_supply)
 WHERE id = sqlc.arg(id) 
     AND chain_id = sqlc.arg(chain_id) 
     AND external_id = sqlc.arg(external_id);

--- a/db/sqlc/tokens.sql.go
+++ b/db/sqlc/tokens.sql.go
@@ -573,7 +573,8 @@ const updateTokenStatus = `-- name: UpdateTokenStatus :execresult
 UPDATE tokens
 SET synced = ?, 
     last_block = ?,
-    analysed_transfers = ?
+    analysed_transfers = ?,
+    total_supply = ?
 WHERE id = ? 
     AND chain_id = ? 
     AND external_id = ?
@@ -583,6 +584,7 @@ type UpdateTokenStatusParams struct {
 	Synced            bool
 	LastBlock         int64
 	AnalysedTransfers int64
+	TotalSupply       annotations.BigInt
 	ID                annotations.Address
 	ChainID           uint64
 	ExternalID        string
@@ -593,6 +595,7 @@ func (q *Queries) UpdateTokenStatus(ctx context.Context, arg UpdateTokenStatusPa
 		arg.Synced,
 		arg.LastBlock,
 		arg.AnalysedTransfers,
+		arg.TotalSupply,
 		arg.ID,
 		arg.ChainID,
 		arg.ExternalID,

--- a/scanner/providers/gitcoin/gitcoin_provider.go
+++ b/scanner/providers/gitcoin/gitcoin_provider.go
@@ -150,7 +150,7 @@ func (g *GitcoinPassport) HoldersBalances(_ context.Context, _ []byte, _ uint64)
 			1, lastUpdateID, true, totalSupply, nil
 	}
 	log.Infof("no changes in Gitcoin Passport balances from last %s", g.cooldown)
-	return nil, 1, lastUpdateID, true, nil, nil
+	return nil, 1, lastUpdateID, true, big.NewInt(0), nil
 }
 
 // updateBalances downloads the json from the API endpoint and stores the

--- a/scanner/providers/gitcoin/gitcoin_provider_test.go
+++ b/scanner/providers/gitcoin/gitcoin_provider_test.go
@@ -37,13 +37,13 @@ func TestGitcoinPassport(t *testing.T) {
 	provider := new(GitcoinPassport)
 	c.Assert(provider.Init(GitcoinPassportConf{endpoints["/original"], time.Second * 2}), qt.IsNil)
 	// start the first download
-	emptyBalances, _, _, _, err := provider.HoldersBalances(context.TODO(), nil, 0)
+	emptyBalances, _, _, _, _, err := provider.HoldersBalances(context.TODO(), nil, 0)
 	c.Assert(err, qt.IsNil)
 	c.Assert(len(emptyBalances), qt.Equals, 0)
 	// wait for the download to finish
 	time.Sleep(2 * time.Second)
 	// check the balances
-	holders, _, _, _, err := provider.HoldersBalances(context.TODO(), nil, 0)
+	holders, _, _, _, _, err := provider.HoldersBalances(context.TODO(), nil, 0)
 	c.Assert(err, qt.IsNil)
 	c.Assert(len(holders), qt.Equals, len(expectedOriginalHolders))
 	for addr, balance := range holders {
@@ -53,14 +53,14 @@ func TestGitcoinPassport(t *testing.T) {
 		c.Assert(balance.String(), qt.Equals, expectedBalance)
 	}
 	// start the second download expecting to use the cached data
-	sameBalances, _, _, _, err := provider.HoldersBalances(context.TODO(), nil, 0)
+	sameBalances, _, _, _, _, err := provider.HoldersBalances(context.TODO(), nil, 0)
 	c.Assert(err, qt.IsNil)
 	// empty results because the data the same
 	c.Assert(len(sameBalances), qt.Equals, 0)
 
 	provider.apiEndpoint = endpoints["/updated"]
 	provider.lastUpdate.Store(time.Time{})
-	emptyBalances, _, _, _, err = provider.HoldersBalances(context.TODO(), nil, 0)
+	emptyBalances, _, _, _, _, err = provider.HoldersBalances(context.TODO(), nil, 0)
 	c.Assert(err, qt.IsNil)
 	c.Assert(len(emptyBalances), qt.Equals, 0)
 
@@ -71,7 +71,7 @@ func TestGitcoinPassport(t *testing.T) {
 		currentHolders[common.HexToAddress(addr)], _ = new(big.Int).SetString(balance, 10)
 	}
 	c.Assert(provider.SetLastBalances(context.TODO(), nil, currentHolders, 0), qt.IsNil)
-	holders, _, _, _, err = provider.HoldersBalances(context.TODO(), nil, 0)
+	holders, _, _, _, _, err = provider.HoldersBalances(context.TODO(), nil, 0)
 	c.Assert(err, qt.IsNil)
 	c.Assert(len(holders), qt.Equals, len(expectedUpdatedHolders))
 	for addr, balance := range holders {

--- a/scanner/providers/holders_provider.go
+++ b/scanner/providers/holders_provider.go
@@ -30,7 +30,8 @@ type HolderProvider interface {
 	// GetBlockNumber calls to the provider.
 	SetLastBlockNumber(blockNumber uint64)
 	// HoldersBalances returns the balances of the token holders for the given
-	// id and delta point in time, from the stored last snapshot.
+	// id and delta point in time, from the stored last snapshot. It also
+	// returns the total supply of tokens as a *big.Int.
 	HoldersBalances(ctx context.Context, id []byte, to uint64) (map[common.Address]*big.Int, uint64, uint64, bool, *big.Int, error)
 	// Close closes the provider and its internal structures.
 	Close() error

--- a/scanner/providers/holders_provider.go
+++ b/scanner/providers/holders_provider.go
@@ -31,7 +31,7 @@ type HolderProvider interface {
 	SetLastBlockNumber(blockNumber uint64)
 	// HoldersBalances returns the balances of the token holders for the given
 	// id and delta point in time, from the stored last snapshot.
-	HoldersBalances(ctx context.Context, id []byte, to uint64) (map[common.Address]*big.Int, uint64, uint64, bool, error)
+	HoldersBalances(ctx context.Context, id []byte, to uint64) (map[common.Address]*big.Int, uint64, uint64, bool, *big.Int, error)
 	// Close closes the provider and its internal structures.
 	Close() error
 	// IsExternal returns true if the provider is an external API.

--- a/scanner/providers/poap/poap_provider.go
+++ b/scanner/providers/poap/poap_provider.go
@@ -132,7 +132,7 @@ func (p *POAPHolderProvider) HoldersBalances(_ context.Context, id []byte, delta
 	// get last snapshot
 	newSnapshot, err := p.lastHolders(eventID)
 	if err != nil {
-		return nil, 0, 0, false, nil, err
+		return nil, 0, 0, false, big.NewInt(0), err
 	}
 	p.snapshotsMtx.RLock()
 	defer p.snapshotsMtx.RUnlock()
@@ -231,8 +231,8 @@ func (p *POAPHolderProvider) Decimals(_ []byte) (uint64, error) {
 // TotalSupply method is not implemented in the POAP external provider. By
 // default it returns 0 and nil error.
 func (p *POAPHolderProvider) TotalSupply(id []byte) (*big.Int, error) {
-	p.snapshotsMtx.Lock()
-	defer p.snapshotsMtx.Unlock()
+	p.snapshotsMtx.RLock()
+	defer p.snapshotsMtx.RUnlock()
 	totalSupply := new(big.Int)
 	if snapshot, exist := p.snapshots[string(id)]; exist {
 		for _, balance := range snapshot.snapshot {

--- a/scanner/providers/poap/poap_provider.go
+++ b/scanner/providers/poap/poap_provider.go
@@ -124,7 +124,7 @@ func (p *POAPHolderProvider) SetLastBalances(_ context.Context, id []byte,
 // API parsing every POAP holder for the event ID provided and calculate the
 // balances of the token holders from the last snapshot.
 func (p *POAPHolderProvider) HoldersBalances(_ context.Context, id []byte, delta uint64) (
-	map[common.Address]*big.Int, uint64, uint64, bool, error,
+	map[common.Address]*big.Int, uint64, uint64, bool, *big.Int, error,
 ) {
 	// parse eventID from id
 	eventID := string(id)
@@ -132,7 +132,7 @@ func (p *POAPHolderProvider) HoldersBalances(_ context.Context, id []byte, delta
 	// get last snapshot
 	newSnapshot, err := p.lastHolders(eventID)
 	if err != nil {
-		return nil, 0, 0, false, err
+		return nil, 0, 0, false, nil, err
 	}
 	p.snapshotsMtx.RLock()
 	defer p.snapshotsMtx.RUnlock()
@@ -149,8 +149,13 @@ func (p *POAPHolderProvider) HoldersBalances(_ context.Context, id []byte, delta
 		from:     from,
 		snapshot: newSnapshot,
 	}
+	// calculate total supply
+	totalSupply := new(big.Int)
+	for _, balance := range finalSnapshot {
+		totalSupply.Add(totalSupply, balance)
+	}
 	// return the final snapshot
-	return finalSnapshot, uint64(len(finalSnapshot)), from, true, nil
+	return finalSnapshot, uint64(len(finalSnapshot)), from, true, totalSupply, nil
 }
 
 // Close method is not implemented in the POAP external provider. By default it
@@ -225,7 +230,16 @@ func (p *POAPHolderProvider) Decimals(_ []byte) (uint64, error) {
 
 // TotalSupply method is not implemented in the POAP external provider. By
 // default it returns 0 and nil error.
-func (p *POAPHolderProvider) TotalSupply(_ []byte) (*big.Int, error) {
+func (p *POAPHolderProvider) TotalSupply(id []byte) (*big.Int, error) {
+	p.snapshotsMtx.Lock()
+	defer p.snapshotsMtx.Unlock()
+	totalSupply := new(big.Int)
+	if snapshot, exist := p.snapshots[string(id)]; exist {
+		for _, balance := range snapshot.snapshot {
+			totalSupply.Add(totalSupply, balance)
+		}
+		return totalSupply, nil
+	}
 	return big.NewInt(0), nil
 }
 

--- a/scanner/providers/poap/poap_provider_test.go
+++ b/scanner/providers/poap/poap_provider_test.go
@@ -39,7 +39,7 @@ func TestPOAP(t *testing.T) {
 
 	provider := new(POAPHolderProvider)
 	c.Assert(provider.Init(POAPConfig{endpoints["/original"], "no-token"}), qt.IsNil)
-	holders, _, _, _, err := provider.HoldersBalances(context.TODO(), nil, 0)
+	holders, _, _, _, _, err := provider.HoldersBalances(context.TODO(), nil, 0)
 	c.Assert(err, qt.IsNil)
 	c.Assert(len(holders), qt.Equals, len(expectedOriginalHolders))
 	for addr, balance := range holders {
@@ -47,13 +47,13 @@ func TestPOAP(t *testing.T) {
 		c.Assert(exists, qt.Equals, true)
 		c.Assert(balance.String(), qt.Equals, expectedBalance)
 	}
-	sameBalances, _, _, _, err := provider.HoldersBalances(context.TODO(), nil, 0)
+	sameBalances, _, _, _, _, err := provider.HoldersBalances(context.TODO(), nil, 0)
 	c.Assert(err, qt.IsNil)
 	// empty results because the data the same
 	c.Assert(len(sameBalances), qt.Equals, 0)
 
 	provider.apiEndpoint = endpoints["/updated"]
-	holders, _, _, _, err = provider.HoldersBalances(context.TODO(), nil, 0)
+	holders, _, _, _, _, err = provider.HoldersBalances(context.TODO(), nil, 0)
 	c.Assert(err, qt.IsNil)
 	c.Assert(len(holders), qt.Equals, len(expectedUpdatedHolders))
 	for addr, balance := range holders {

--- a/scanner/providers/web3/erc721_provider.go
+++ b/scanner/providers/web3/erc721_provider.go
@@ -115,7 +115,7 @@ func (p *ERC721HolderProvider) SetLastBlockNumber(blockNumber uint64) {
 // of new transfers, the last block scanned, if the provider is synced and an
 // error if it exists.
 func (p *ERC721HolderProvider) HoldersBalances(ctx context.Context, _ []byte, fromBlock uint64) (
-	map[common.Address]*big.Int, uint64, uint64, bool, error,
+	map[common.Address]*big.Int, uint64, uint64, bool, *big.Int, error,
 ) {
 	// calculate the range of blocks to scan, by default take the last block
 	// scanned and scan to the latest block, calculate the latest block if the
@@ -125,7 +125,7 @@ func (p *ERC721HolderProvider) HoldersBalances(ctx context.Context, _ []byte, fr
 		var err error
 		toBlock, err = p.LatestBlockNumber(ctx, nil)
 		if err != nil {
-			return nil, 0, fromBlock, false, err
+			return nil, 0, fromBlock, false, nil, err
 		}
 	}
 	log.Infow("scan iteration",
@@ -138,7 +138,7 @@ func (p *ERC721HolderProvider) HoldersBalances(ctx context.Context, _ []byte, fr
 	startTime := time.Now()
 	logs, lastBlock, synced, err := rangeOfLogs(ctx, p.client, p.address, fromBlock, toBlock, LOG_TOPIC_ERC20_TRANSFER)
 	if err != nil {
-		return nil, 0, fromBlock, false, err
+		return nil, 0, fromBlock, false, nil, err
 	}
 	// encode the number of new transfers
 	newTransfers := uint64(len(logs))
@@ -147,7 +147,7 @@ func (p *ERC721HolderProvider) HoldersBalances(ctx context.Context, _ []byte, fr
 	for _, currentLog := range logs {
 		logData, err := p.contract.ERC721ContractFilterer.ParseTransfer(currentLog)
 		if err != nil {
-			return nil, newTransfers, lastBlock, false, fmt.Errorf("[ERC721] %w: %s: %w", ErrParsingTokenLogs, p.address.Hex(), err)
+			return nil, newTransfers, lastBlock, false, nil, fmt.Errorf("[ERC721] %w: %s: %w", ErrParsingTokenLogs, p.address.Hex(), err)
 		}
 		// update balances
 		if toBalance, ok := balances[logData.To]; ok {
@@ -168,7 +168,7 @@ func (p *ERC721HolderProvider) HoldersBalances(ctx context.Context, _ []byte, fr
 		"took", time.Since(startTime).Seconds(),
 		"progress", fmt.Sprintf("%d%%", (fromBlock*100)/toBlock))
 	p.synced.Store(synced)
-	return balances, newTransfers, lastBlock, synced, nil
+	return balances, newTransfers, lastBlock, synced, nil, nil
 }
 
 // Close method is not implemented for ERC721 tokens.

--- a/scanner/providers/web3/erc777_provider.go
+++ b/scanner/providers/web3/erc777_provider.go
@@ -115,7 +115,7 @@ func (p *ERC777HolderProvider) SetLastBlockNumber(blockNumber uint64) {
 // of new transfers, the last block scanned, if the provider is synced and an
 // error if it exists.
 func (p *ERC777HolderProvider) HoldersBalances(ctx context.Context, _ []byte, fromBlock uint64) (
-	map[common.Address]*big.Int, uint64, uint64, bool, error,
+	map[common.Address]*big.Int, uint64, uint64, bool, *big.Int, error,
 ) {
 	// calculate the range of blocks to scan, by default take the last block
 	// scanned and scan to the latest block, calculate the latest block if the
@@ -125,7 +125,7 @@ func (p *ERC777HolderProvider) HoldersBalances(ctx context.Context, _ []byte, fr
 		var err error
 		toBlock, err = p.LatestBlockNumber(ctx, nil)
 		if err != nil {
-			return nil, 0, fromBlock, false, err
+			return nil, 0, fromBlock, false, nil, err
 		}
 	}
 	log.Infow("scan iteration",
@@ -138,7 +138,7 @@ func (p *ERC777HolderProvider) HoldersBalances(ctx context.Context, _ []byte, fr
 	startTime := time.Now()
 	logs, lastBlock, synced, err := rangeOfLogs(ctx, p.client, p.address, fromBlock, toBlock, LOG_TOPIC_ERC20_TRANSFER)
 	if err != nil {
-		return nil, 0, fromBlock, false, err
+		return nil, 0, fromBlock, false, nil, err
 	}
 	// encode the number of new transfers
 	newTransfers := uint64(len(logs))
@@ -147,7 +147,7 @@ func (p *ERC777HolderProvider) HoldersBalances(ctx context.Context, _ []byte, fr
 	for _, currentLog := range logs {
 		logData, err := p.contract.ERC777ContractFilterer.ParseTransfer(currentLog)
 		if err != nil {
-			return nil, newTransfers, lastBlock, false, errors.Join(ErrParsingTokenLogs, fmt.Errorf("[ERC777] %s: %w", p.address, err))
+			return nil, newTransfers, lastBlock, false, nil, errors.Join(ErrParsingTokenLogs, fmt.Errorf("[ERC777] %s: %w", p.address, err))
 		}
 		// update balances
 		if toBalance, ok := balances[logData.To]; ok {
@@ -167,7 +167,7 @@ func (p *ERC777HolderProvider) HoldersBalances(ctx context.Context, _ []byte, fr
 		"blocks/s", 1000*float32(lastBlock-fromBlock)/float32(time.Since(startTime).Milliseconds()),
 		"took", time.Since(startTime).Seconds(),
 		"progress", fmt.Sprintf("%d%%", (fromBlock*100)/toBlock))
-	return balances, newTransfers, lastBlock, synced, nil
+	return balances, newTransfers, lastBlock, synced, nil, nil
 }
 
 // Close method is not implemented for ERC777 tokens.

--- a/scanner/providers/web3/erc777_provider.go
+++ b/scanner/providers/web3/erc777_provider.go
@@ -147,7 +147,8 @@ func (p *ERC777HolderProvider) HoldersBalances(ctx context.Context, _ []byte, fr
 	for _, currentLog := range logs {
 		logData, err := p.contract.ERC777ContractFilterer.ParseTransfer(currentLog)
 		if err != nil {
-			return nil, newTransfers, lastBlock, false, nil, errors.Join(ErrParsingTokenLogs, fmt.Errorf("[ERC777] %s: %w", p.address, err))
+			return nil, newTransfers, lastBlock, false, nil,
+				errors.Join(ErrParsingTokenLogs, fmt.Errorf("[ERC777] %s: %w", p.address, err))
 		}
 		// update balances
 		if toBalance, ok := balances[logData.To]; ok {

--- a/scanner/providers/web3/errors.go
+++ b/scanner/providers/web3/errors.go
@@ -8,4 +8,5 @@ var (
 	ErrInitializingContract   = fmt.Errorf("error initializing token contract")
 	ErrScanningTokenLogs      = fmt.Errorf("error scanning token logs")
 	ErrParsingTokenLogs       = fmt.Errorf("error parsing token logs")
+	ErrGettingTotalSupply     = fmt.Errorf("error getting total supply")
 )


### PR DESCRIPTION
keeping totalSupply updated, totalSupply method updated in every token holder provider implementation

It solves #140.

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- New Feature: Updated the `HoldersBalances` function across various providers (`GitcoinPassport`, `POAPHolderProvider`, `ERC20HolderProvider`, `ERC721HolderProvider`, `ERC777HolderProvider`) to return an additional parameter representing the total supply of tokens. This ensures that the total supply is always up-to-date and returned along with individual balances.
- Refactor: Modified the `tokens` table in the database to update the column `total_supply` for storing the total supply of tokens.
- Test: Updated test cases to accommodate changes in the `HoldersBalances` function and total supply calculation.
- Chore: Enhanced error handling with a new error variable `ErrGettingTotalSupply` for issues related to fetching the total supply of tokens.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->