### PR TITLE
feature: modify the token holder endpoint to return its balance

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -218,7 +218,7 @@ Returns the information about the token referenced by the provided ID and chain 
 | 500 | `error getting last block number from web3 endpoint` | 5021 | 
 
 ### GET `/tokens/{tokenID}/holders/{holderID}?chainID={chainID}&externalID={externalID}`
-Returns if the holder ID is already registered in the database as a holder of the token ID and chain ID provided, the external ID is optional.
+Returns the holder balance if the holder ID is already registered in the database as a holder of the token ID and chain ID provided, the external ID is optional.
 
 > `chainID` URL parameter is *mandatory*.
 
@@ -226,8 +226,11 @@ Returns if the holder ID is already registered in the database as a holder of th
 
 - 📥 response:
 
-```
-true|false
+```json
+{
+    "holderID": "0x1234",
+    "balance": "1234567890"
+}
 ```
 
 - ⚠️ errors:
@@ -237,6 +240,7 @@ true|false
 | 400 | `malformed token information` | 4001 |
 | 400 | `malformed chain ID` | 4018 |
 | 404 | `no token found` | 4003 |
+| 404 | `token holder not found for the token provided` | 4022 |
 | 500 | `error getting token holders` | 5006 | 
 
 --- 

--- a/api/README.md
+++ b/api/README.md
@@ -228,7 +228,6 @@ Returns the holder balance if the holder ID is already registered in the databas
 
 ```json
 {
-    "holderID": "0x1234",
     "balance": "1234567890"
 }
 ```

--- a/api/errors.go
+++ b/api/errors.go
@@ -123,6 +123,11 @@ var (
 		HTTPstatus: apirest.HTTPstatusBadRequest,
 		Err:        fmt.Errorf("malformed pagination params"),
 	}
+	ErrNoTokenHolderFound = apirest.APIerror{
+		Code:       4022,
+		HTTPstatus: apirest.HTTPstatusNotFound,
+		Err:        fmt.Errorf("token holder not found for the token provided"),
+	}
 	ErrCantCreateToken = apirest.APIerror{
 		Code:       5000,
 		HTTPstatus: apirest.HTTPstatusInternalErr,

--- a/api/tokens.go
+++ b/api/tokens.go
@@ -580,10 +580,14 @@ func (capi *census3API) getTokenHolder(msg *api.APIdata, ctx *httprouter.HTTPCon
 		}
 		return ErrCantGetTokenHolders.WithErr(err)
 	}
+	balance, ok := new(big.Int).SetString(holder.Balance, 10)
+	if !ok {
+		return ErrCantGetTokenHolders.With("error parsing balance")
+	}
 	// build response and send it
 	res, err := json.Marshal(&GetTokenHolderResponse{
 		HolderID: holderID.String(),
-		Balance:  holder.Balance,
+		Balance:  balance.String(),
 	})
 	if err != nil {
 		return ErrEncodeTokenHolders.WithErr(err)

--- a/api/tokens.go
+++ b/api/tokens.go
@@ -586,8 +586,7 @@ func (capi *census3API) getTokenHolder(msg *api.APIdata, ctx *httprouter.HTTPCon
 	}
 	// build response and send it
 	res, err := json.Marshal(&GetTokenHolderResponse{
-		HolderID: holderID.String(),
-		Balance:  balance.String(),
+		Balance: balance.String(),
 	})
 	if err != nil {
 		return ErrEncodeTokenHolders.WithErr(err)

--- a/api/tokens.go
+++ b/api/tokens.go
@@ -40,7 +40,7 @@ func (capi *census3API) initTokenHandlers() error {
 		return err
 	}
 	if err := capi.endpoint.RegisterMethod("/tokens/{tokenID}/holders/{holderID}", "GET",
-		api.MethodAccessTypePublic, capi.isTokenHolder); err != nil {
+		api.MethodAccessTypePublic, capi.getTokenHolder); err != nil {
 		return err
 	}
 	return capi.endpoint.RegisterMethod("/tokens/types", "GET",
@@ -533,7 +533,7 @@ func (capi *census3API) getToken(msg *api.APIdata, ctx *httprouter.HTTPContext) 
 	return ctx.Send(res, api.HTTPstatusOK)
 }
 
-func (capi *census3API) isTokenHolder(msg *api.APIdata, ctx *httprouter.HTTPContext) error {
+func (capi *census3API) getTokenHolder(msg *api.APIdata, ctx *httprouter.HTTPContext) error {
 	// get contract address from the tokenID query param and decode check if
 	// it is provided, if not return an error
 	strAddress := ctx.URLParam("tokenID")
@@ -565,17 +565,30 @@ func (capi *census3API) isTokenHolder(msg *api.APIdata, ctx *httprouter.HTTPCont
 	holderID := common.HexToAddress(strHolderID)
 	internalCtx, cancel := context.WithTimeout(ctx.Request.Context(), getTokenTimeout)
 	defer cancel()
-
-	exists, err := capi.db.QueriesRO.ExistTokenHolder(internalCtx, queries.ExistTokenHolderParams{
+	// get token holder information from the database
+	holder, err := capi.db.QueriesRO.GetTokenHolder(internalCtx, queries.GetTokenHolderParams{
 		TokenID:    address.Bytes(),
 		HolderID:   holderID.Bytes(),
 		ChainID:    uint64(chainID),
 		ExternalID: externalID,
 	})
 	if err != nil {
+		// if the error is sql.ErrNoRows, return a 404 error, otherwise return
+		// a 500 error
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrNoTokenHolderFound.WithErr(err)
+		}
 		return ErrCantGetTokenHolders.WithErr(err)
 	}
-	return ctx.Send([]byte(strconv.FormatBool(exists)), api.HTTPstatusOK)
+	// build response and send it
+	res, err := json.Marshal(&GetTokenHolderResponse{
+		HolderID: holderID.String(),
+		Balance:  holder.Balance,
+	})
+	if err != nil {
+		return ErrEncodeTokenHolders.WithErr(err)
+	}
+	return ctx.Send(res, api.HTTPstatusOK)
 }
 
 // getTokenTypes handler returns the list of string names of the currently

--- a/api/types.go
+++ b/api/types.go
@@ -169,8 +169,7 @@ type TokenHoldersAtBlock struct {
 }
 
 type GetTokenHolderResponse struct {
-	HolderID string `json:"holderID"`
-	Balance  string `json:"balance"`
+	Balance string `json:"balance"`
 }
 
 type GetHoldersAtLastBlockResponse struct {

--- a/api/types.go
+++ b/api/types.go
@@ -168,6 +168,11 @@ type TokenHoldersAtBlock struct {
 	Holders     map[string]string `json:"holders"`
 }
 
+type GetTokenHolderResponse struct {
+	HolderID string `json:"holderID"`
+	Balance  string `json:"balance"`
+}
+
 type GetHoldersAtLastBlockResponse struct {
 	Done           bool                 `json:"done"`
 	Error          error                `json:"error"`

--- a/db/queries/holders.sql
+++ b/db/queries/holders.sql
@@ -10,7 +10,8 @@ FROM token_holders
 WHERE token_id = ? 
     AND holder_id = ? 
     AND chain_id = ?
-    AND external_id = ?;
+    AND external_id = ?
+    AND balance > '0';
 
 -- name: ExistTokenHolder :one
 SELECT EXISTS (

--- a/db/sqlc/holders.sql.go
+++ b/db/sqlc/holders.sql.go
@@ -196,6 +196,7 @@ WHERE token_id = ?
     AND holder_id = ? 
     AND chain_id = ?
     AND external_id = ?
+    AND balance > '0'
 `
 
 type GetTokenHolderParams struct {


### PR DESCRIPTION
token holder endpoint modified to return the holder balance instead of just a boolean, solving #147



<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- New Feature: Enhanced the token holder endpoint to return not only the holder's ID but also their balance. This provides more detailed information about each token holder.
- Bug Fix: Updated error handling to include a new error code `ErrNoTokenHolderFound` (4022) for cases when a token holder is not found for the provided token, improving error specificity.
- Refactor: Renamed the `isTokenHolder` function to `getTokenHolder` to better reflect its enhanced functionality.
- Chore: Updated the database query to retrieve and return only token holders with a balance greater than zero, ensuring more relevant data is returned.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->