### PR TITLE
Feature: Implement different strategies to get the token creation block

### DIFF
--- a/scanner/providers/helpers.go
+++ b/scanner/providers/helpers.go
@@ -9,8 +9,23 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethclient"
 	"go.vocdoni.io/dvote/log"
 )
+
+// ClientSupportsGetCode checks if the given client supports the `eth_getCode`
+// method. It returns true if it is supported and false otherwise.
+func ClientSupportsGetCode(ctx context.Context, cli *ethclient.Client, controlAddr common.Address) bool {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	// get the latest block number
+	lastBlock, err := cli.BlockNumber(ctx)
+	if err != nil {
+		return false
+	}
+	_, err = cli.CodeAt(ctx, controlAddr, big.NewInt(int64(lastBlock/2)))
+	return err == nil
+}
 
 // CalcPartialHolders calculates the partial holders from the current and new holders
 // maps. It returns a map with the partial holders and their balances. The final

--- a/scanner/providers/web3/erc20_provider.go
+++ b/scanner/providers/web3/erc20_provider.go
@@ -307,19 +307,15 @@ func (p *ERC20HolderProvider) LatestBlockNumber(ctx context.Context, _ []byte) (
 // CreationBlock returns the creation block of the current token set in the
 // provider. It gets the creation block from the client. It also receives an
 // external ID but it is not used by the provider. It uses the
-// creationBlockInRange function to calculate the creation block in the range
-// of blocks.
+// creationBlock function to calculate the creation block of a web3 provider
+// contract.
 func (p *ERC20HolderProvider) CreationBlock(ctx context.Context, _ []byte) (uint64, error) {
-	var err error
 	if p.creationBlock == 0 {
-		var lastBlock uint64
-		lastBlock, err = p.LatestBlockNumber(ctx, nil)
-		if err != nil {
-			return 0, err
-		}
-		p.creationBlock, err = creationBlockInRange(p.client, ctx, p.address, 0, lastBlock)
+		var err error
+		p.creationBlock, err = creationBlock(p.client, ctx, p.address)
+		return p.creationBlock, err
 	}
-	return p.creationBlock, err
+	return p.creationBlock, nil
 }
 
 // IconURI method is not implemented for ERC20 tokens.


### PR DESCRIPTION
As #141 said, some web3 rpc endpoints fail when calling eth_getCode. This method requires an archive node to work and not all rpc nodes are so.

To manage this situation, we need different strategies for calculating the creation block, trying to reduce the number of failures and the number of requests required.

There are the proposed strategies:

1. Current one: Using bubble search strategy calling eth_getCode from block 0 and the last one until find the creation block.
2. Read owner tx: List the transfers of the owner of the contract looking for the deploy transfer to know its block.
3. Read from the beginning: Use block 1 as starting block.

But option 2 can be achieved because the ERC20 standard does not implement the `Owner` method like OpenZepellinERC20 does. So only option 3 was implemented as a backup for option 1.


<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- New Feature: Added a function to check if the Ethereum client supports the `eth_getCode` method, improving compatibility with different clients.
- Refactor: Updated the `CreationBlock` function in the `ERC20HolderProvider` struct to use the new `creationBlock` function for calculating the creation block of a contract. This enhances the accuracy and efficiency of the operation.
- New Feature: Introduced a function to calculate the block number at which a contract was created, providing more precise information about contract lifecycle events.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->