### PR TITLE
bug: base too many requests error

### DIFF
--- a/scanner/providers/web3/web3_provider.go
+++ b/scanner/providers/web3/web3_provider.go
@@ -113,7 +113,8 @@ func rangeOfLogs(ctx context.Context, client *ethclient.Client, addr common.Addr
 					log.Warnf("too much results on query, decreasing blocks to %d", blocksRange)
 					continue
 				}
-				return finalLogs, fromBlock, false, errors.Join(ErrScanningTokenLogs, fmt.Errorf("%s: %w", addr.Hex(), err))
+				log.Error(errors.Join(ErrScanningTokenLogs, fmt.Errorf("%s: %w", addr.Hex(), err)))
+				return finalLogs, fromBlock, false, nil
 			}
 			// if there are logs, add them to the final list and update the
 			// counter


### PR DESCRIPTION
fixes #150 
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Bug Fix: Improved error handling in the `rangeOfLogs` function within the Web3 provider. Now, instead of returning an error when encountering too many results on a query, it logs an error message and returns `nil`. This change enhances the robustness of the system by preventing unnecessary disruptions due to excessive query results.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->