### PR TITLE
bug: initial tokens strategy predicate issue

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -268,7 +268,7 @@ func (capi *census3API) CreateInitialTokens(tokensPath string) error {
 			return err
 		}
 		strategyID, err := capi.createDefaultTokenStrategy(ctx, qtx,
-			addr, token.ChainID, token.ChainAddress, token.Symbol, token.ExternalID)
+			addr, token.ChainID, chainAddress, symbol, token.ExternalID)
 		if err != nil {
 			return err
 		}

--- a/api/const.go
+++ b/api/const.go
@@ -24,6 +24,7 @@ const (
 	getTokensTimeout   = time.Second * 20
 	createTokenTimeout = time.Second * 10
 	getTokenTimeout    = time.Second * 15
+	deleteTokenTimeout = time.Second * 60
 )
 
 const (

--- a/api/tokens.go
+++ b/api/tokens.go
@@ -353,7 +353,7 @@ func (capi *census3API) deleteToken(msg *api.APIdata, ctx *httprouter.HTTPContex
 	// get externalID from query params and decode it as string, it is optional
 	// so if it's not provided continue
 	externalID := ctx.Request.URL.Query().Get("externalID")
-	internalCtx, cancel := context.WithTimeout(ctx.Request.Context(), createTokenTimeout)
+	internalCtx, cancel := context.WithTimeout(ctx.Request.Context(), deleteTokenTimeout)
 	defer cancel()
 	tx, err := capi.db.RW.BeginTx(internalCtx, nil)
 	if err != nil {


### PR DESCRIPTION
issue with initial tokens default strategies predicates fixed, delete token endpoint timeout increased

closes #152 
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

---
- Bug Fix: Resolved an issue with the default token strategies predicates in `api.go` to ensure correct functionality.
- Performance: Increased the timeout for the delete token endpoint from 10 seconds to 60 seconds in `const.go`, improving reliability during peak loads.
- Refactor: Updated the timeout value used in the `deleteToken` function in `tokens.go` for consistency and clarity.
---
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->