### PR TITLE
bug: too many requests workaround

### DIFF
--- a/scanner/providers/farcaster/provider.go
+++ b/scanner/providers/farcaster/provider.go
@@ -238,7 +238,10 @@ func (p *FarcasterProvider) ScanLogsIDRegistry(ctx context.Context, fromBlock, t
 		web3.LOG_TOPIC_FARCASTER_REGISTER,
 	)
 	if err != nil {
-		return nil, 0, false, err
+		if !errors.Is(err, web3.ErrTooManyRequests) {
+			return nil, 0, false, err
+		}
+		log.Debug("too many requests error, handling scanned logs")
 	}
 	// encode the number of new registers
 	newFIDs := make(map[uint64]common.Address, 0)

--- a/scanner/providers/web3/errors.go
+++ b/scanner/providers/web3/errors.go
@@ -7,6 +7,7 @@ var (
 	ErrConnectingToWeb3Client = fmt.Errorf("client not set")
 	ErrInitializingContract   = fmt.Errorf("error initializing token contract")
 	ErrScanningTokenLogs      = fmt.Errorf("error scanning token logs")
+	ErrTooManyRequests        = fmt.Errorf("web3 endpoint returns too many requests")
 	ErrParsingTokenLogs       = fmt.Errorf("error parsing token logs")
 	ErrGettingTotalSupply     = fmt.Errorf("error getting total supply")
 )

--- a/scanner/providers/web3/web3_provider.go
+++ b/scanner/providers/web3/web3_provider.go
@@ -134,6 +134,11 @@ func RangeOfLogs(ctx context.Context, client *ethclient.Client, addr common.Addr
 					log.Warnf("too much results on query, decreasing blocks to %d", blocksRange)
 					continue
 				}
+				// if error is about too many requests, return the logs scanned
+				// until now and the last block scanned with an specific error
+				if strings.Contains(strings.ToLower(err.Error()), "too many requests") {
+					return finalLogs, fromBlock, false, errors.Join(ErrTooManyRequests, fmt.Errorf("%s: %w", addr.Hex(), err))
+				}
 				return finalLogs, fromBlock, false, errors.Join(ErrScanningTokenLogs, fmt.Errorf("%s: %w", addr.Hex(), err))
 			}
 			// if there are logs, add them to the final list and update the


### PR DESCRIPTION
handling too many requests error and storing logs received to retry in the next iteration
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Bug Fix: Improved error handling in `FarcasterProvider` and `Web3Provider`. Now, when the "too many requests" error is encountered during log scanning, the process will return the logs scanned up to that point along with the last block scanned. This ensures partial results are available even under high load conditions.
- Refactor: Introduced a new error variable `ErrTooManyRequests` in `web3/errors.go` for better identification and handling of situations where the web3 endpoint returns too many requests.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->