### PR TITLE
bug: wrong synced status when outdated chains

### DIFF
--- a/scanner/providers/web3/erc721_provider.go
+++ b/scanner/providers/web3/erc721_provider.go
@@ -75,6 +75,9 @@ func (p *ERC721HolderProvider) SetRef(iref any) error {
 	if p.contract, err = erc721.NewERC721Contract(address, client); err != nil {
 		return errors.Join(ErrInitializingContract, fmt.Errorf("[ERC721] %s: %w", p.address, err))
 	}
+	if ref.CreationBlock > 0 {
+		p.creationBlock = ref.CreationBlock
+	}
 	// reset the internal attributes
 	p.address = address
 	p.chainID = ref.ChainID
@@ -82,7 +85,6 @@ func (p *ERC721HolderProvider) SetRef(iref any) error {
 	p.symbol = ""
 	p.decimals = 0
 	p.totalSupply = nil
-	p.creationBlock = 0
 	p.lastNetworkBlock = 0
 	p.synced.Store(false)
 	return nil
@@ -117,6 +119,14 @@ func (p *ERC721HolderProvider) SetLastBlockNumber(blockNumber uint64) {
 func (p *ERC721HolderProvider) HoldersBalances(ctx context.Context, _ []byte, fromBlock uint64) (
 	map[common.Address]*big.Int, uint64, uint64, bool, *big.Int, error,
 ) {
+	// if the last network block is lower than the last scanned block, and the
+	// last scanned block is equal to the creation block, it means that the
+	// last network block is outdated, so it returns that it is not synced and
+	// an error
+	if fromBlock >= p.lastNetworkBlock && fromBlock == p.creationBlock {
+		return nil, 0, fromBlock, false, big.NewInt(0),
+			errors.New("outdated last network block, it will retry in the next iteration")
+	}
 	// calculate the range of blocks to scan, by default take the last block
 	// scanned and scan to the latest block, calculate the latest block if the
 	// current last network block is not defined

--- a/scanner/providers/web3/erc777_provider.go
+++ b/scanner/providers/web3/erc777_provider.go
@@ -75,6 +75,9 @@ func (p *ERC777HolderProvider) SetRef(iref any) error {
 	if p.contract, err = erc777.NewERC777Contract(address, client); err != nil {
 		return errors.Join(ErrInitializingContract, fmt.Errorf("[ERC777] %s: %w", p.address, err))
 	}
+	if ref.CreationBlock > 0 {
+		p.creationBlock = ref.CreationBlock
+	}
 	// reset the internal attributes
 	p.address = address
 	p.chainID = ref.ChainID
@@ -82,7 +85,6 @@ func (p *ERC777HolderProvider) SetRef(iref any) error {
 	p.symbol = ""
 	p.decimals = 0
 	p.totalSupply = nil
-	p.creationBlock = 0
 	p.lastNetworkBlock = 0
 	p.synced.Store(false)
 	return nil
@@ -117,6 +119,14 @@ func (p *ERC777HolderProvider) SetLastBlockNumber(blockNumber uint64) {
 func (p *ERC777HolderProvider) HoldersBalances(ctx context.Context, _ []byte, fromBlock uint64) (
 	map[common.Address]*big.Int, uint64, uint64, bool, *big.Int, error,
 ) {
+	// if the last network block is lower than the last scanned block, and the
+	// last scanned block is equal to the creation block, it means that the
+	// last network block is outdated, so it returns that it is not synced and
+	// an error
+	if fromBlock >= p.lastNetworkBlock && fromBlock == p.creationBlock {
+		return nil, 0, fromBlock, false, big.NewInt(0),
+			errors.New("outdated last network block, it will retry in the next iteration")
+	}
 	// calculate the range of blocks to scan, by default take the last block
 	// scanned and scan to the latest block, calculate the latest block if the
 	// current last network block is not defined

--- a/scanner/providers/web3/web3_provider.go
+++ b/scanner/providers/web3/web3_provider.go
@@ -17,8 +17,9 @@ import (
 )
 
 type Web3ProviderRef struct {
-	HexAddress string
-	ChainID    uint64
+	HexAddress    string
+	ChainID       uint64
+	CreationBlock uint64
 }
 
 type Web3ProviderConfig struct {

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -23,14 +23,15 @@ import (
 // ScannerToken includes the information of a token that the scanner needs to
 // scan it.
 type ScannerToken struct {
-	Address     common.Address
-	ChainID     uint64
-	Type        uint64
-	ExternalID  string
-	LastBlock   uint64
-	Ready       bool
-	Synced      bool
-	totalSupply *big.Int
+	Address       common.Address
+	ChainID       uint64
+	Type          uint64
+	ExternalID    string
+	LastBlock     uint64
+	CreationBlock uint64
+	Ready         bool
+	Synced        bool
+	totalSupply   *big.Int
 }
 
 // Scanner is the scanner that scans the tokens and saves the holders in the
@@ -138,6 +139,7 @@ func (s *Scanner) Start(ctx context.Context) {
 				// scan the token
 				holders, newTransfers, lastBlock, synced, totalSupply, err := s.ScanHolders(ctx, token)
 				if err != nil {
+					atSyncGlobal = false
 					log.Error(err)
 					continue
 				}
@@ -203,14 +205,15 @@ func (s *Scanner) TokensToScan(ctx context.Context) ([]*ScannerToken, error) {
 			totalSupply = nil
 		}
 		tokens = append(tokens, &ScannerToken{
-			Address:     common.BytesToAddress(token.ID),
-			ChainID:     token.ChainID,
-			Type:        token.TypeID,
-			ExternalID:  token.ExternalID,
-			LastBlock:   uint64(token.LastBlock),
-			Ready:       token.CreationBlock > 0 && token.LastBlock >= token.CreationBlock,
-			Synced:      token.Synced,
-			totalSupply: totalSupply,
+			Address:       common.BytesToAddress(token.ID),
+			ChainID:       token.ChainID,
+			Type:          token.TypeID,
+			ExternalID:    token.ExternalID,
+			LastBlock:     uint64(token.LastBlock),
+			CreationBlock: uint64(token.CreationBlock),
+			Ready:         token.CreationBlock > 0 && token.LastBlock >= token.CreationBlock,
+			Synced:        token.Synced,
+			totalSupply:   totalSupply,
 		})
 	}
 	// get old not synced tokens from the database (2)
@@ -253,14 +256,15 @@ func (s *Scanner) TokensToScan(ctx context.Context) ([]*ScannerToken, error) {
 				totalSupply = nil
 			}
 			tokens = append(tokens, &ScannerToken{
-				Address:     common.BytesToAddress(token.ID),
-				ChainID:     token.ChainID,
-				Type:        token.TypeID,
-				ExternalID:  token.ExternalID,
-				LastBlock:   uint64(token.LastBlock),
-				Ready:       token.CreationBlock > 0 && token.LastBlock >= token.CreationBlock,
-				Synced:      token.Synced,
-				totalSupply: totalSupply,
+				Address:       common.BytesToAddress(token.ID),
+				ChainID:       token.ChainID,
+				Type:          token.TypeID,
+				ExternalID:    token.ExternalID,
+				LastBlock:     uint64(token.LastBlock),
+				CreationBlock: uint64(token.CreationBlock),
+				Ready:         token.CreationBlock > 0 && token.LastBlock >= token.CreationBlock,
+				Synced:        token.Synced,
+				totalSupply:   totalSupply,
 			})
 		}
 	}
@@ -275,14 +279,15 @@ func (s *Scanner) TokensToScan(ctx context.Context) ([]*ScannerToken, error) {
 			totalSupply = nil
 		}
 		tokens = append(tokens, &ScannerToken{
-			Address:     common.BytesToAddress(token.ID),
-			ChainID:     token.ChainID,
-			Type:        token.TypeID,
-			ExternalID:  token.ExternalID,
-			LastBlock:   uint64(token.LastBlock),
-			Ready:       token.CreationBlock > 0 && token.LastBlock >= token.CreationBlock,
-			Synced:      token.Synced,
-			totalSupply: totalSupply,
+			Address:       common.BytesToAddress(token.ID),
+			ChainID:       token.ChainID,
+			Type:          token.TypeID,
+			ExternalID:    token.ExternalID,
+			LastBlock:     uint64(token.LastBlock),
+			CreationBlock: uint64(token.CreationBlock),
+			Ready:         token.CreationBlock > 0 && token.LastBlock >= token.CreationBlock,
+			Synced:        token.Synced,
+			totalSupply:   totalSupply,
 		})
 	}
 	// update the tokens to scan in the scanner and return them
@@ -320,8 +325,9 @@ func (s *Scanner) ScanHolders(ctx context.Context, token *ScannerToken) (
 	// if the provider is not an external one, instance the current token
 	if !provider.IsExternal() {
 		if err := provider.SetRef(web3.Web3ProviderRef{
-			HexAddress: token.Address.Hex(),
-			ChainID:    token.ChainID,
+			HexAddress:    token.Address.Hex(),
+			ChainID:       token.ChainID,
+			CreationBlock: token.CreationBlock,
 		}); err != nil {
 			return nil, 0, token.LastBlock, token.Synced, nil, err
 		}


### PR DESCRIPTION
Now the web3 holder providers check if the last scanned block is the same that the creation block, and both are greater than the last network block (cached), and return and error to prevent false synced statuses.

Tokens with a creation block newer than the last cached network block will be scanned when the last block is updated.
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

---
- Bug Fix: Enhanced the `SetRef` function across ERC20, ERC721, and ERC777 providers to correctly set the creation block when it's greater than 0.
- New Feature: Improved the `HoldersBalances` function to handle outdated last network blocks and added error handling for these scenarios.
- Refactor: Updated the `Web3ProviderRef` struct and `ScannerToken` in web3_provider.go and scanner.go files respectively, with a new `CreationBlock` field for better data organization.
---
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->