### PR TITLE
Allow duplicate token entries in the lexer (such as `ETH OR ETH`) in order to allow non weighted censuses

### DIFF
--- a/helpers/lexer/eval_test.go
+++ b/helpers/lexer/eval_test.go
@@ -131,7 +131,7 @@ func TestEval(t *testing.T) {
 		token, err := lx.Parse("even AND odd")
 		c.Assert(err, qt.IsNil)
 		// force undefined data
-		token.Childs.Tokens["naturals"] = NewLiteralToken("naturals")
+		token.Childs.Tokens[1] = NewLiteralToken("naturals")
 		_, err = NewEval[[]int](testEvalOperators).EvalToken(token, nil)
 		c.Assert(err, qt.IsNotNil)
 	})

--- a/helpers/lexer/lexer_test.go
+++ b/helpers/lexer/lexer_test.go
@@ -36,8 +36,8 @@ var (
 				Level:    0,
 				Operator: "AND",
 				Tokens: []*Token{
-					&Token{Type: TokenTypeLiteral, Literal: "Monkey$ Token"},
-					&Token{Type: TokenTypeLiteral, Literal: "ETH"},
+					{Type: TokenTypeLiteral, Literal: "Monkey$ Token"},
+					{Type: TokenTypeLiteral, Literal: "ETH"},
 				},
 				firstToken:  "Monkey$ Token",
 				secondToken: "ETH",
@@ -50,8 +50,8 @@ var (
 				Level:    0,
 				Operator: "AND",
 				Tokens: []*Token{
-					&Token{Type: TokenTypeLiteral, Literal: "ETH"},
-					&Token{Type: TokenTypeLiteral, Literal: "ETH"},
+					{Type: TokenTypeLiteral, Literal: "ETH"},
+					{Type: TokenTypeLiteral, Literal: "ETH"},
 				},
 				firstToken:  "ETH",
 				secondToken: "ETH",
@@ -64,8 +64,8 @@ var (
 				Level:    0,
 				Operator: "OR",
 				Tokens: []*Token{
-					&Token{Type: TokenTypeLiteral, Literal: "ETH"},
-					&Token{Type: TokenTypeLiteral, Literal: "ETH"},
+					{Type: TokenTypeLiteral, Literal: "ETH"},
+					{Type: TokenTypeLiteral, Literal: "ETH"},
 				},
 				firstToken:  "ETH",
 				secondToken: "ETH",
@@ -79,16 +79,16 @@ var (
 				Level:    0,
 				Operator: "AND",
 				Tokens: []*Token{
-					&Token{Type: TokenTypeLiteral, Literal: "Monkey$ Token"},
-					&Token{
+					{Type: TokenTypeLiteral, Literal: "Monkey$ Token"},
+					{
 						Type: TokenTypeGroup,
 						Childs: &Group{
 							ID:       1,
 							Level:    1,
 							Operator: "OR",
 							Tokens: []*Token{
-								&Token{Type: TokenTypeLiteral, Literal: "ETH"},
-								&Token{Type: TokenTypeLiteral, Literal: "BTC"},
+								{Type: TokenTypeLiteral, Literal: "ETH"},
+								{Type: TokenTypeLiteral, Literal: "BTC"},
 							},
 							firstToken:  "ETH",
 							secondToken: "BTC",
@@ -107,37 +107,37 @@ var (
 				Level:    0,
 				Operator: "AND",
 				Tokens: []*Token{
-					&Token{
+					{
 						Type: TokenTypeGroup,
 						Childs: &Group{
 							ID:       1,
 							Level:    1,
 							Operator: "AND",
 							Tokens: []*Token{
-								&Token{Type: TokenTypeLiteral, Literal: "Monkey$ Token"},
-								&Token{Type: TokenTypeLiteral, Literal: "ANT"},
+								{Type: TokenTypeLiteral, Literal: "Monkey$ Token"},
+								{Type: TokenTypeLiteral, Literal: "ANT"},
 							},
 							firstToken:  "Monkey$ Token",
 							secondToken: "ANT",
 						},
 					},
-					&Token{
+					{
 						Type: TokenTypeGroup,
 						Childs: &Group{
 							ID:       2,
 							Level:    1,
 							Operator: "OR",
 							Tokens: []*Token{
-								&Token{Type: TokenTypeLiteral, Literal: "ETH"},
-								&Token{
+								{Type: TokenTypeLiteral, Literal: "ETH"},
+								{
 									Type: TokenTypeGroup,
 									Childs: &Group{
 										ID:       3,
 										Level:    1,
 										Operator: "AND",
 										Tokens: []*Token{
-											&Token{Type: TokenTypeLiteral, Literal: "USDC"},
-											&Token{Type: TokenTypeLiteral, Literal: "BTC"},
+											{Type: TokenTypeLiteral, Literal: "USDC"},
+											{Type: TokenTypeLiteral, Literal: "BTC"},
 										},
 										firstToken:  "USDC",
 										secondToken: "BTC",

--- a/helpers/lexer/token.go
+++ b/helpers/lexer/token.go
@@ -181,10 +181,8 @@ func (g *Group) AddToken(t *Token) error {
 	}
 	if g.firstToken == "" {
 		g.firstToken = t.Literal
-		// g.Tokens[0] = t
 	} else if g.secondToken == "" {
 		g.secondToken = t.Literal
-		// g.Tokens[1] = t
 	}
 	g.Tokens = append(g.Tokens, t)
 	return nil
@@ -193,7 +191,9 @@ func (g *Group) AddToken(t *Token) error {
 // Complete method returns if the current group is already completed which means
 // that it has an operator and two tokens (first and second one).
 func (g *Group) Complete() bool {
-	return g.Operator != "" && g.firstToken != "" && g.secondToken != "" && len(g.Tokens) == 2
+	return g.Operator != "" && g.firstToken != "" && g.secondToken != "" &&
+		len(g.Tokens) == 2 && g.Tokens[0].Literal == g.firstToken &&
+		g.Tokens[1].Literal == g.secondToken
 }
 
 func ScapeTokenSymbol(symbol string) string {

--- a/helpers/lexer/token.go
+++ b/helpers/lexer/token.go
@@ -55,9 +55,9 @@ func (t *Token) String() string {
 	}
 	// return string group
 	return fmt.Sprintf("(%s %s %s)",
-		t.Childs.Tokens[t.Childs.firstToken],
+		t.Childs.Tokens[0],
 		t.Childs.Operator,
-		t.Childs.Tokens[t.Childs.secondToken],
+		t.Childs.Tokens[1],
 	)
 }
 
@@ -142,7 +142,7 @@ type Group struct {
 	ID          int
 	Operator    string
 	Level       int
-	Tokens      map[string]*Token
+	Tokens      []*Token
 	firstToken  string
 	secondToken string
 }
@@ -153,7 +153,7 @@ func NewEmptyGroup(level int) *Group {
 	return &Group{
 		ID:     rand.Intn(maxGroupID),
 		Level:  level,
-		Tokens: make(map[string]*Token),
+		Tokens: make([]*Token, 0),
 	}
 }
 
@@ -163,8 +163,8 @@ func (g *Group) MarshalJSON() ([]byte, error) {
 	return json.Marshal(map[string]any{
 		"operator": g.Operator,
 		"tokens": []*Token{
-			g.Tokens[g.firstToken],
-			g.Tokens[g.secondToken],
+			g.Tokens[0],
+			g.Tokens[1],
 		},
 	})
 }
@@ -175,18 +175,18 @@ func (g *Group) MarshalJSON() ([]byte, error) {
 // assigns the provided token as first token if the group has not one. If it
 // already has a first token, the provided token will be the second one.
 func (g *Group) AddToken(t *Token) error {
-	if _, ok := g.Tokens[t.Literal]; ok {
-		return nil
-	}
-	if len(g.Tokens) == 2 {
+	// parase Tokens array and if the token is already in the group, skip
+	if g.secondToken != "" {
 		return fmt.Errorf("current group already has two tokens")
 	}
 	if g.firstToken == "" {
 		g.firstToken = t.Literal
-	} else {
+		// g.Tokens[0] = t
+	} else if g.secondToken == "" {
 		g.secondToken = t.Literal
+		// g.Tokens[1] = t
 	}
-	g.Tokens[t.Literal] = t
+	g.Tokens = append(g.Tokens, t)
 	return nil
 }
 

--- a/helpers/lexer/token_test.go
+++ b/helpers/lexer/token_test.go
@@ -44,8 +44,8 @@ func TestToken(t *testing.T) {
 		c.Assert(tg.Childs.AddToken(NewLiteralToken("BTC")), qt.IsNil)
 		c.Assert(tg.String(), qt.Equals, "('ETH' AND 'BTC')")
 		c.Assert(tg.Childs.Complete(), qt.IsTrue)
-		// already exists
-		c.Assert(tg.Childs.AddToken(NewLiteralToken("BTC")), qt.IsNil)
+		// full group
+		c.Assert(tg.Childs.AddToken(NewLiteralToken("BTC")), qt.IsNotNil)
 		// full group
 		c.Assert(tg.Childs.AddToken(NewLiteralToken("USDC")), qt.IsNotNil)
 	})


### PR DESCRIPTION



<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

---
- New Feature: Introduced support for duplicate token entries in the lexer, enabling logical expressions like `ETH AND ETH` and `ETH OR ETH`.
- Refactor: Updated data structures and methods related to token parsing and storage for better handling of duplicate tokens.
- Test: Revised test cases to validate the new behavior of allowing duplicate tokens.
- Improvement: Enhanced error handling in the `AddToken` method and completeness check in the `Complete` method.
- Bug Fix: Fixed issues with handling repeated tokens in non-weighted censuses.
---
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->