### PR TITLE
truncate scores instead of round it to the nearest integer

### DIFF
--- a/scanner/providers/gitcoin/gitcoin_provider_test.go
+++ b/scanner/providers/gitcoin/gitcoin_provider_test.go
@@ -15,8 +15,8 @@ import (
 var (
 	expectedOriginalHolders = map[string]string{
 		"0x85ff01cff157199527528788ec4ea6336615c989": "22",
-		"0x7587cfbd20e5a970209526b4d1f69dbaae8bed37": "25",
-		"0x7bec70fa7ef926878858333b0fa581418e2ef0b5": "23",
+		"0x7587cfbd20e5a970209526b4d1f69dbaae8bed37": "24",
+		"0x7bec70fa7ef926878858333b0fa581418e2ef0b5": "22",
 	}
 	expectedUpdatedHolders = map[string]string{
 		"0x85ff01cff157199527528788ec4ea6336615c989": "-2",

--- a/scanner/providers/gitcoin/gitcoin_score.go
+++ b/scanner/providers/gitcoin/gitcoin_score.go
@@ -82,12 +82,8 @@ func parseScore(input any) *big.Int {
 	default:
 		return nil
 	}
-	// if the score is between 0 and 1, set it to 1 to avoid rounding errors
-	if fScore > 0 && fScore < 1 {
-		fScore = 1
-	}
-	// omit scores that are 0
-	if biScore := big.NewInt(int64(math.Round(fScore))); biScore.Cmp(big.NewInt(0)) == 1 {
+	// truncate the score to the nearest integer and return it as a big.Int
+	if biScore := big.NewInt(int64(math.Trunc(fScore))); biScore.Cmp(big.NewInt(0)) == 1 {
 		return biScore
 	}
 	return nil


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Bug Fix: Updated the score processing logic in Gitcoin provider. Scores are now truncated to the nearest integer instead of being rounded, providing a more accurate representation of the original scores.
- Test: Adjusted expected values in the `gitcoin_provider_test.go` to align with the new truncation logic for scores.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->