### PR TITLE
bug: gitcoin status and censuses issues

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -33,6 +33,7 @@ import (
 )
 
 type Census3APIConf struct {
+	MainCtx         context.Context
 	Hostname        string
 	Port            int
 	DataDir         string

--- a/api/helpers.go
+++ b/api/helpers.go
@@ -315,7 +315,7 @@ func (capi *census3API) CalculateStrategyHolders(ctx context.Context,
 			}
 		}
 		// init the operators and the predicate evaluator
-		operators := strategyoperators.InitOperators(capi.db.QueriesRO, tokensInfo)
+		operators := strategyoperators.InitOperators(capi.conf.MainCtx, capi.db.QueriesRO, tokensInfo)
 		eval := lexer.NewEval[*strategyoperators.StrategyIteration](operators.Map())
 		// execute the evaluation of the predicate
 		res, err := eval.EvalToken(validPredicate, progressCh)

--- a/cmd/census3/main.go
+++ b/cmd/census3/main.go
@@ -246,7 +246,9 @@ func main() {
 		log.Infof("no admin token defined, using a random one: %s", config.adminToken)
 	}
 	// Start the API
+	ctx, cancel := context.WithCancel(context.Background())
 	apiService, err := api.Init(database, api.Census3APIConf{
+		MainCtx:         ctx,
 		Hostname:        "0.0.0.0",
 		Port:            config.port,
 		DataDir:         config.dataDir,
@@ -265,7 +267,6 @@ func main() {
 		}
 		log.Info("initial tokens created, or at least tried to")
 	}()
-	ctx, cancel := context.WithCancel(context.Background())
 	go hc.Start(ctx)
 
 	metrics.NewCounter(fmt.Sprintf("census3_info{version=%q,chains=%q}",

--- a/helpers/strategyoperators/operators.go
+++ b/helpers/strategyoperators/operators.go
@@ -12,6 +12,12 @@ import (
 	"github.com/vocdoni/census3/helpers/lexer"
 )
 
+// databaseOperatorsTimeout is the timeout used to query the database for holders
+// balances and other information during the AND and OR query operators. It is
+// set to 30 seconds to handle large databases and slow connections and avoid
+// blocking the strategy evaluation for too long.
+const databaseOperatorsTimeout = time.Second * 30
+
 // AND method returns a AND operator function that can be used in a strategy
 // evaluation. The AND operator returns the common token holders between symbols
 // database information or previous operations results. It applies a fixed
@@ -123,7 +129,7 @@ func (op *StrategyOperators) OR_MUL() func(iter *lexer.Iteration[*StrategyIterat
 // a balance normalization to the max number of decimals and also returns the
 // max number of decimals.
 func (op *StrategyOperators) andOperator(iter *lexer.Iteration[*StrategyIteration]) (map[string][2]*big.Int, uint64, error) {
-	interalCtx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	interalCtx, cancel := context.WithTimeout(op.ctx, databaseOperatorsTimeout)
 	defer cancel()
 	// get information about the current operation
 	symbolA, dataA := iter.A()
@@ -203,7 +209,7 @@ func (op *StrategyOperators) andOperator(iter *lexer.Iteration[*StrategyIteratio
 // applies a balance normalization to the max number of decimals and also
 // returns the max number of decimals.
 func (op *StrategyOperators) orOperator(iter *lexer.Iteration[*StrategyIteration]) (map[string][2]*big.Int, uint64, error) {
-	interalCtx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	interalCtx, cancel := context.WithTimeout(op.ctx, databaseOperatorsTimeout)
 	defer cancel()
 	// get information about the current operation
 	symbolA, dataA := iter.A()

--- a/helpers/strategyoperators/strategyoperators.go
+++ b/helpers/strategyoperators/strategyoperators.go
@@ -88,14 +88,16 @@ type StrategyIteration struct {
 // associated with a SQL database as data source. It brings access to SQL data
 // inside the lexer evaluator operators.
 type StrategyOperators struct {
+	ctx        context.Context
 	db         *queries.Queries
 	tokensInfo map[string]*TokenInformation
 }
 
 // InitOperators function creates a new StrategyOperators struct with the db
 // instance and info about tokens provided.
-func InitOperators(db *queries.Queries, info map[string]*TokenInformation) *StrategyOperators {
+func InitOperators(ctx context.Context, db *queries.Queries, info map[string]*TokenInformation) *StrategyOperators {
 	return &StrategyOperators{
+		ctx:        ctx,
 		db:         db,
 		tokensInfo: info,
 	}

--- a/helpers/strategyoperators/strategyoperators_test.go
+++ b/helpers/strategyoperators/strategyoperators_test.go
@@ -112,7 +112,7 @@ func mockedStrategyOperator(dataDir string) (*StrategyOperators, error) {
 			return nil, err
 		}
 	}
-	return InitOperators(database.QueriesRO, mockedTokenInformation), tx.Commit()
+	return InitOperators(context.Background(), database.QueriesRO, mockedTokenInformation), tx.Commit()
 }
 
 var combinatorsTestBalances = map[string][2]*big.Int{

--- a/scanner/providers/gitcoin/gitcoin_provider.go
+++ b/scanner/providers/gitcoin/gitcoin_provider.go
@@ -328,10 +328,9 @@ func (g *GitcoinPassport) BlockRootHash(_ context.Context, insertTime uint64) ([
 }
 
 // LatestBlockNumber method returns the number of the last block of the network,
-// in this case, the last block number is emulated by the last time where an
-// score was updated or inserted in the database.
+// in this case, the last block number is emulated the current time in unix
 func (g *GitcoinPassport) LatestBlockNumber(_ context.Context, _ []byte) (uint64, error) {
-	return uint64(g.lastInsert.Load()), nil
+	return uint64(time.Now().Unix()), nil
 }
 
 // CreationBlock is not implemented for Gitcoin Passport.


### PR DESCRIPTION
Solves #186 

* Fix issue with gitcoin token progress always returning the current time in unix as the gitcoin LastBlockNumber instead of the time the last snapshot was downloaded, to avoid negative values when the provider is downloading.
* Fix `context deadline exceeded` error when evaluating strategy to create a census when large list of owners are involved. The main context has also been propagated to the strategy operators to create inner contexts based on it.
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Refactor: Introduced context propagation in `Census3APIConf` and `StrategyOperators` to improve control over concurrent operations.
- New Feature: Added a constant `databaseOperatorsTimeout` for database query timeout, enhancing code maintainability by avoiding hardcoded values.
- Bug Fix: Updated the `LatestBlockNumber` method in `GitcoinPassport` to return the current time in Unix format, ensuring more accurate block number reporting.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->